### PR TITLE
Add Dia TTS

### DIFF
--- a/NeuralCodecs.Core/NeuralCodecs.Core.csproj
+++ b/NeuralCodecs.Core/NeuralCodecs.Core.csproj
@@ -6,7 +6,12 @@
     <Nullable>enable</Nullable>
 	  <IsPackable>false</IsPackable>
 	  <AssemblyName>NeuralCodecs.Core</AssemblyName>
+	  <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Utils\TensorUtils.cs" />
+  </ItemGroup>
 
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
@@ -15,7 +20,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
+	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
 	  <PackageReference Include="NAudio" Version="2.2.1" />
 	</ItemGroup>
 </Project>

--- a/NeuralCodecs.Core/Utils/Extensions.cs
+++ b/NeuralCodecs.Core/Utils/Extensions.cs
@@ -1,5 +1,3 @@
-using System.Threading;
-
 namespace NeuralCodecs.Core.Utils;
 
 /// <summary>
@@ -25,8 +23,7 @@ internal static class Extensions
     {
         ArgumentNullException.ThrowIfNull(source);
         ArgumentNullException.ThrowIfNull(destination);
-        if (bufferSize <= 0)
-            throw new ArgumentOutOfRangeException(nameof(bufferSize));
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(bufferSize);
 
         var buffer = new byte[bufferSize];
         long totalBytesRead = 0;
@@ -34,14 +31,20 @@ internal static class Extensions
         while (true)
         {
             int bytesRead = await source.ReadAsync(buffer, ct).ConfigureAwait(false);
-            if (bytesRead == 0) break; // End of stream
+            if (bytesRead == 0)
+            {
+                break; // End of stream
+            }
 
             await destination.WriteAsync(buffer.AsMemory(0, bytesRead), ct).ConfigureAwait(false);
 
             totalBytesRead += bytesRead;
             progress?.Report(totalBytesRead);
 
-            if (ct.IsCancellationRequested) break;
+            if (ct.IsCancellationRequested)
+            {
+                break;
+            }
         }
 
         // Ensure writes are flushed

--- a/NeuralCodecs.Core/Utils/MathUtils.cs
+++ b/NeuralCodecs.Core/Utils/MathUtils.cs
@@ -10,7 +10,11 @@ public static class MathUtils
     /// <returns>The greatest common divisor of the two numbers</returns>
     public static long GCD(long a, long b)
     {
-        if (a == 0 && b == 0) throw new ArgumentException("Both numbers cannot be 0");
+        if (a == 0 && b == 0)
+        {
+            throw new ArgumentException("Both numbers cannot be 0");
+        }
+
         a = Math.Abs(a);
         b = Math.Abs(b);
         while (b != 0)
@@ -21,6 +25,7 @@ public static class MathUtils
         }
         return a;
     }
+
     /// <summary>
     /// Calculates Greatest Common Divisor (GCD) of two numbers.
     /// </summary>
@@ -29,7 +34,11 @@ public static class MathUtils
     /// <returns>The greatest common divisor of the two numbers</returns>
     public static long GCD(int a, int b)
     {
-        if (a == 0 && b == 0) throw new ArgumentException("Both numbers cannot be 0");
+        if (a == 0 && b == 0)
+        {
+            throw new ArgumentException("Both numbers cannot be 0");
+        }
+
         a = Math.Abs(a);
         b = Math.Abs(b);
         while (b != 0)
@@ -40,6 +49,7 @@ public static class MathUtils
         }
         return a;
     }
+
     /// <summary>
     /// Calculates Least Common Multiple (LCM) of two numbers.
     /// </summary>
@@ -58,7 +68,7 @@ public static class MathUtils
     /// <returns>The linear scale value</returns>
     public static double DecibelToLinear(double db)
     {
-        return Math.Pow(10.0, (db / 20.0));
+        return Math.Pow(10.0, db / 20.0);
     }
 
     /// <summary>
@@ -68,7 +78,11 @@ public static class MathUtils
     /// <returns>The decibel value</returns>
     public static double LinearToDecibel(double linear)
     {
-        if (linear <= 0) throw new ArgumentException("Linear value must be positive");
+        if (linear <= 0)
+        {
+            throw new ArgumentException("Linear value must be positive");
+        }
+
         return 20.0 * Math.Log10(linear);
     }
 
@@ -92,6 +106,13 @@ public static class MathUtils
         return 700.0 * (Math.Pow(10.0, mel / 2595.0) - 1.0);
     }
 
+    /// <summary>
+    /// Computes the error function (erf) of a given value.
+    /// </summary>
+    /// <remarks>Represents the probability that a random variable with a normal distribution
+    /// is within a certain range of values.</remarks>
+    /// <param name="x">The input value for which to compute the error function. Can be positive or negative.</param>
+    /// <returns>The computed value of the error function for the input <paramref name="x"/>. The result is in the range [-1, 1].</returns>
     public static double Erf(double x)
     {
         const double a1 = 0.254829592;
@@ -104,12 +125,15 @@ public static class MathUtils
         // Save the sign of x
         int sign = 1;
         if (x < 0)
+        {
             sign = -1;
+        }
+
         x = Math.Abs(x);
 
         // A&S formula 7.1.26
-        double t = 1.0 / (1.0 + p * x);
-        double y = 1.0 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.Exp(-x * x);
+        double t = 1.0 / (1.0 + (p * x));
+        double y = 1.0 - (((((((((a5 * t) + a4) * t) + a3) * t) + a2) * t) + a1) * t * Math.Exp(-x * x));
 
         return sign * y;
     }

--- a/NeuralCodecs.Core/Utils/NAudioUtils.cs
+++ b/NeuralCodecs.Core/Utils/NAudioUtils.cs
@@ -1,0 +1,324 @@
+﻿using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+
+namespace NeuralCodecs.Core.Utils;
+
+internal static class NAudioUtils
+{
+    private static Func<string, WaveFileReader> _readerFactory = path => new WaveFileReader(path);
+
+    /// <summary>
+    /// Loads audio from a file and converts it to float array format
+    /// </summary>
+    /// <param name="path">Path to the audio file</param>
+    /// <param name="targetSampleRate">Desired sample rate, will resample if needed</param>
+    /// <param name="format">Format of the output data (interleaved or deinterleaved)</param>
+    /// <param name="mono">Whether to convert to mono (single channel)</param>
+    /// <param name="bitDepth">Bit depth (16 or 32)</param>
+    /// <returns>Audio data as float array with values from -1.0 to 1.0</returns>
+    public static float[] LoadAudio(string path, int targetSampleRate,
+        AudioInterleaving format = AudioInterleaving.Deinterleaved, bool mono = true, int bitDepth = 16)
+    {
+        if (string.IsNullOrEmpty(path) || !File.Exists(path))
+        {
+            throw new FileNotFoundException("Input file does not exist", path);
+        }
+
+        using var reader = CreateReader(path);
+        return LoadAudioFromReader(reader, targetSampleRate, format, mono, bitDepth);
+    }
+
+    /// <summary>
+    /// Loads stereo audio from a file into a float array
+    /// </summary>
+    /// <param name="path">Path to the audio file</param>
+    /// <param name="targetSampleRate">Desired sample rate</param>
+    /// <param name="format">Format of the output data (interleaved or deinterleaved)</param>
+    /// <param name="bitDepth">Bit depth (16 or 32)</param>
+    /// <returns>Stereo audio data as float array</returns>
+    public static float[] LoadStereoAudio(string path, int targetSampleRate,
+        AudioInterleaving format = AudioInterleaving.Interleaved, int bitDepth = 16)
+    {
+        if (string.IsNullOrEmpty(path) || !File.Exists(path))
+        {
+            throw new FileNotFoundException("Input file does not exist", path);
+        }
+
+        using var reader = CreateReader(path);
+        return LoadStereoAudioFromReader(reader, targetSampleRate, format, bitDepth);
+    }
+
+    /// <summary>
+    /// Loads stereo audio in deinterleaved format to a multidimensional array [channel, sample]
+    /// </summary>
+    /// <param name="filePath">Path to the audio file</param>
+    /// <param name="targetSampleRate">Desired sample rate</param>
+    /// <param name="bitDepth">Bit depth (16 or 32)</param>
+    /// <returns>Stereo audio as [2, samples] float array</returns>
+    public static float[,] LoadStereoAudioMultidimensional(string filePath, int targetSampleRate, int bitDepth = 16)
+    {
+        if (bitDepth is not 16 and not 32)
+        {
+            throw new ArgumentException("Bit depth must be either 16 or 32");
+        }
+
+        using var reader = CreateReader(filePath);
+
+        if (reader.WaveFormat.Channels != 2)
+        {
+            throw new ArgumentException("Input file must be stereo (2 channels)");
+        }
+
+        if (reader.WaveFormat.BitsPerSample != bitDepth)
+        {
+            throw new ArgumentException($"Input file has {reader.WaveFormat.BitsPerSample} bits per sample, but {bitDepth} was requested");
+        }
+
+        if (reader.WaveFormat.SampleRate != targetSampleRate)
+        {
+            throw new NotImplementedException("Resampling for multidimensional stereo is not implemented");
+        }
+
+        int bytesPerSample = bitDepth / 8;
+        long totalSamplesPerChannel = reader.Length / (bytesPerSample * 2);
+        float[,] result = new float[2, (int)totalSamplesPerChannel];
+
+        byte[] audioData = new byte[reader.Length];
+        if (reader.Read(audioData, 0, audioData.Length) == 0)
+        {
+            throw new ArgumentException("Input file is empty");
+        }
+
+        if (bitDepth == 16)
+        {
+            // Convert value range -32768 to 32767 => -1.0 to 1.0
+            for (long i = 0; i < totalSamplesPerChannel; i++)
+            {
+                int leftOffset = (int)(i * 2 * bytesPerSample);
+                short leftSample = BitConverter.ToInt16(audioData, leftOffset);
+                result[0, (int)i] = leftSample / 32768f;
+
+                // Get right channel sample and convert to float
+                int rightOffset = (int)((i * 2 * bytesPerSample) + bytesPerSample);
+                short rightSample = BitConverter.ToInt16(audioData, rightOffset);
+                result[1, (int)i] = rightSample / 32768f;
+            }
+        }
+        else
+        {
+            // Convert value range -2147483648 to 2147483647 => -1.0 to 1.0
+            for (long i = 0; i < totalSamplesPerChannel; i++)
+            {
+                int leftOffset = (int)(i * 2 * bytesPerSample);
+                int leftSample = BitConverter.ToInt32(audioData, leftOffset);
+                result[0, (int)i] = leftSample / 2147483648f;
+
+                int rightOffset = (int)((i * 2 * bytesPerSample) + bytesPerSample);
+                int rightSample = BitConverter.ToInt32(audioData, rightOffset);
+                result[1, (int)i] = rightSample / 2147483648f;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Resamples audio using NAudio's high-quality resampler
+    /// </summary>
+    public static float[] Resample(float[] input, int channels, int sourceSampleRate, int targetSampleRate)
+    {
+        var waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(sourceSampleRate, channels);
+        var resampler = new WdlResamplingSampleProvider(
+            new FloatArraySampleProvider(waveFormat, input),
+            targetSampleRate
+        );
+
+        var outputLength = (int)((long)input.Length * targetSampleRate / sourceSampleRate);
+        if (outputLength % channels != 0)
+        {
+            outputLength += channels - (outputLength % channels);
+        }
+
+        var output = new float[outputLength];
+        resampler.Read(output, 0, output.Length);
+
+        return output;
+    }
+
+    /// <summary>
+    /// Saves audio data to a WAV file
+    /// </summary>
+    /// <param name="path">Output file path</param>
+    /// <param name="buffer">Audio data as float array</param>
+    /// <param name="sampleRate">Sample rate in Hz</param>
+    /// <param name="channels">Number of channels</param>
+    /// <param name="format">Format of the input data (interleaved or deinterleaved)</param>
+    /// <param name="bitDepth">Bit depth (16 or 32)</param>
+    public static void SaveAudio(string path, float[] buffer, int sampleRate, int channels,
+        AudioInterleaving format = AudioInterleaving.Interleaved, int bitDepth = 16)
+    {
+        if (buffer == null)
+        {
+            throw new ArgumentNullException(nameof(buffer));
+        }
+
+        if (channels <= 0)
+        {
+            throw new ArgumentException("Channel count must be greater than 0", nameof(channels));
+        }
+
+        if (bitDepth is not 16 and not 32)
+        {
+            throw new ArgumentException("Bit depth must be either 16 or 32");
+        }
+
+        if (channels == 2 && format == AudioInterleaving.Deinterleaved)
+        {
+            buffer = AudioUtils.DeinterleaveToInterleave(buffer);
+        }
+
+        var waveFormat = bitDepth == 16
+            ? new WaveFormat(sampleRate, channels)
+            : WaveFormat.CreateIeeeFloatWaveFormat(sampleRate, channels);
+
+        using var writer = new WaveFileWriter(path, waveFormat);
+        writer.WriteSamples(buffer, 0, buffer.Length);
+    }
+
+    /// <summary>
+    /// Loads audio from a reader and converts it to float array format
+    /// </summary>
+    internal static float[] LoadAudioFromReader(WaveFileReader reader, int targetSampleRate,
+        AudioInterleaving format = AudioInterleaving.Deinterleaved, bool mono = true, int bitDepth = 16)
+    {
+        if (bitDepth is not 16 and not 32)
+        {
+            throw new ArgumentException("Bit depth must be either 16 or 32");
+        }
+
+        if (reader.WaveFormat.BitsPerSample != bitDepth)
+        {
+            throw new ArgumentException($"Input file has {reader.WaveFormat.BitsPerSample} bits per sample, but {bitDepth} was requested");
+        }
+
+        var channels = reader.WaveFormat.Channels;
+        var bytesPerSample = bitDepth / 8;
+        var totalSamples = reader.Length / (bytesPerSample * channels);
+
+        byte[] audioData = new byte[reader.Length];
+        if (reader.Read(audioData, 0, audioData.Length) == 0)
+        {
+            throw new ArgumentException("Input file is empty");
+        }
+
+        float[] buffer = AudioUtils.AudioBytesToFloatArray(audioData, bitDepth, totalSamples, channels);
+
+        if (mono && channels > 1)
+        {
+            buffer = AudioUtils.ConvertToMono(buffer, channels);
+            channels = 1;
+        }
+
+        if (reader.WaveFormat.SampleRate != targetSampleRate)
+        {
+            buffer = NAudioUtils.Resample(buffer, channels, reader.WaveFormat.SampleRate, targetSampleRate);
+        }
+
+        if (channels == 2 && format == AudioInterleaving.Deinterleaved)
+        {
+            buffer = AudioUtils.InterleaveToDeinterleave(buffer);
+        }
+
+        return buffer;
+    }
+
+    /// <summary>
+    /// Loads stereo audio from a reader into a float array
+    /// </summary>
+    internal static float[] LoadStereoAudioFromReader(WaveFileReader reader, int targetSampleRate,
+        AudioInterleaving format = AudioInterleaving.Interleaved, int bitDepth = 16)
+    {
+        if (bitDepth is not 16 and not 32)
+        {
+            throw new ArgumentException("Bit depth must be either 16 or 32");
+        }
+
+        if (reader.WaveFormat.Channels != 2)
+        {
+            throw new ArgumentException("Input file must be stereo (2 channels)");
+        }
+
+        if (reader.WaveFormat.BitsPerSample != bitDepth)
+        {
+            throw new ArgumentException($"Input file has {reader.WaveFormat.BitsPerSample} bits per sample, but {bitDepth} was requested");
+        }
+
+        var bytesPerSample = bitDepth / 8;
+        var totalSamplesPerChannel = reader.Length / (bytesPerSample * 2);
+
+        byte[] audioData = new byte[reader.Length];
+        if (reader.Read(audioData, 0, audioData.Length) == 0)
+        {
+            throw new ArgumentException("Input file is empty");
+        }
+
+        float[] buffer = AudioUtils.AudioBytesToFloatArray(audioData, bitDepth, totalSamplesPerChannel * 2, 2);
+
+        if (reader.WaveFormat.SampleRate != targetSampleRate)
+        {
+            buffer = NAudioUtils.Resample(buffer, 2, reader.WaveFormat.SampleRate, targetSampleRate);
+        }
+
+        if (format == AudioInterleaving.Deinterleaved)
+        {
+            buffer = AudioUtils.InterleaveToDeinterleave(buffer);
+        }
+
+        return buffer;
+    }
+
+    /// <summary>
+    /// Sets a custom reader factory for creating WaveFileReader instances
+    /// </summary>
+    internal static void SetReaderFactory(Func<string, WaveFileReader> factory)
+    {
+        _readerFactory = factory;
+    }
+
+    /// <summary>
+    /// Creates a wave file reader using the configured factory
+    /// </summary>
+    internal static WaveFileReader CreateReader(string path)
+    {
+        return _readerFactory(path);
+    }
+
+    /// <summary>
+    /// Helper class for providing float arrays as NAudio sample providers
+    /// </summary>
+    public class FloatArraySampleProvider : ISampleProvider
+    {
+        private readonly float[] _samples;
+        private int _position;
+
+        public FloatArraySampleProvider(WaveFormat waveFormat, float[] samples)
+        {
+            WaveFormat = waveFormat;
+            _samples = samples;
+            _position = 0;
+        }
+
+        public WaveFormat WaveFormat { get; }
+
+        public int Read(float[] buffer, int offset, int count)
+        {
+            var availableSamples = Math.Min(count, _samples.Length - _position);
+            if (availableSamples > 0)
+            {
+                Array.Copy(_samples, _position, buffer, offset, availableSamples);
+                _position += availableSamples;
+            }
+            return availableSamples;
+        }
+    }
+}

--- a/NeuralCodecs.Torch.Examples/NeuralCodecs.Torch.Examples.csproj
+++ b/NeuralCodecs.Torch.Examples/NeuralCodecs.Torch.Examples.csproj
@@ -5,12 +5,13 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="ScottPlot" Version="5.0.55" />
-    <PackageReference Include="SkiaSharp" Version="3.116.1" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
 	<PackageReference Include="TorchSharp-cuda-windows" Version="0.105.0" />
   </ItemGroup>

--- a/NeuralCodecs.Torch/AudioTools/AudioSignal.cs
+++ b/NeuralCodecs.Torch/AudioTools/AudioSignal.cs
@@ -323,7 +323,6 @@ public class AudioSignal : IDisposable
 
     #region Methods
 
-    // Additional indexing support
     public AudioSignal this[params int[] indices]
     {
         get
@@ -342,15 +341,15 @@ public class AudioSignal : IDisposable
         {
             if (value.AudioData is not null && AudioData is not null)
             {
-                AudioData.index_put_(indices, value.AudioData);
+                AudioData.index_put_(value.AudioData, indices);
             }
             if (_loudness is not null && value._loudness is not null)
             {
-                _loudness.index_put_(indices, value._loudness);
+                _loudness.index_put_(value._loudness, indices);
             }
             if (_stftData is not null && value._stftData is not null)
             {
-                _stftData.index_put_(indices, value._stftData);
+                _stftData.index_put_(value._stftData, indices);
             }
         }
     }

--- a/NeuralCodecs.Torch/Config/DAC/DACConfig.cs
+++ b/NeuralCodecs.Torch/Config/DAC/DACConfig.cs
@@ -23,7 +23,6 @@ public class DACConfig: IModelConfig
     [JsonPropertyName("model_type")]
     public string Architecture { get; set; } = "dac";
 
-    // TODO: Double-check these defaults
     /// <summary>
     /// Gets or sets the dimensionality of each codebook entry.
     /// </summary>
@@ -103,7 +102,6 @@ public class DACConfig: IModelConfig
     [JsonIgnore]
     public static DACConfig DAC44kHz => new();
 
-    // TODO
     [JsonIgnore]
     public static DACConfig DAC44kHz_16kbps => new()
     {

--- a/NeuralCodecs.Torch/Config/DAC/DACUnpickler.cs
+++ b/NeuralCodecs.Torch/Config/DAC/DACUnpickler.cs
@@ -6,345 +6,506 @@ using TorchSharp;
 using TorchSharp.PyBridge;
 using static TorchSharp.torch;
 
-// Based on TorchSharp.PyBridge.PytorchUnpickler
-// NC prefix is used to avoid conflicts with existing classes
-namespace NeuralCodecs.Torch.Config.DAC
+namespace NeuralCodecs.Torch.Config.DAC;
+
+/// <summary>
+/// Provides functionality to unpickle and load DAC (Descript Audio Codec) model weights and configurations
+/// from PyTorch-compatible pickle files and safetensors format.
+/// </summary>
+/// <remarks>
+/// This class is based on TorchSharp.PyBridge.PytorchUnpickler and handles the deserialization of DAC models
+/// that have been saved in Python PyTorch format. It supports both traditional pickle-based .pth files
+/// and the newer safetensors format.
+/// </remarks>
+public class DACUnpickler
 {
-    public class DACUnpickler
+    /// <summary>
+    /// Custom unpickler implementation that extends Razorvine.Pickle.Unpickler to handle DAC-specific tensor loading.
+    /// </summary>
+    private class CustomDACUnpickler : Unpickler
     {
-        private class CustomDACUnpickler : Unpickler
+        private readonly ZipArchive _archive;
+        private bool _skipTensorRead;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomDACUnpickler"/> class.
+        /// </summary>
+        /// <param name="archive">The ZIP archive containing the model data.</param>
+        /// <param name="skipTensorRead">If true, tensors will not be immediately loaded into memory.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="archive"/> is null.</exception>
+        public CustomDACUnpickler(ZipArchive archive, bool skipTensorRead = false)
         {
-            private readonly ZipArchive _archive;
-            private bool _skipTensorRead;
-
-            public CustomDACUnpickler(ZipArchive archive, bool skipTensorRead = false)
-            {
-                _archive = archive ?? throw new ArgumentNullException(nameof(archive));
-                _skipTensorRead = skipTensorRead;
-            }
-
-            protected override object persistentLoad(object pid)
-            {
-                if (pid is not object[] array)
-                    throw new InvalidOperationException("Invalid persistent load data");
-
-                if ((string)array[0] != "storage")
-                    throw new NotImplementedException("Unknown persistent id loaded");
-
-                string name = ((ClassDictConstructor)array[1]).name;
-                string archiveKey = (string)array[2];
-                var scalarType = GetScalarTypeFromStorageName(name);
-
-                var entry = _archive.Entries
-                    .Select((e, i) => (Entry: e, Index: i))
-                    .FirstOrDefault(e => e.Entry.FullName.EndsWith("data/" + archiveKey));
-
-                if (entry.Entry == null)
-                    throw new InvalidOperationException($"Archive entry not found: data/{archiveKey}");
-
-                return new NCTensorStream
-                {
-                    ArchiveIndex = entry.Index,
-                    ArchiveEntry = entry.Entry,
-                    DType = scalarType,
-                    SkipTensorRead = _skipTensorRead
-                };
-            }
+            _archive = archive ?? throw new ArgumentNullException(nameof(archive));
+            _skipTensorRead = skipTensorRead;
         }
 
-        private static torch.ScalarType GetScalarTypeFromStorageName(string storage)
+        /// <summary>
+        /// Handles persistent loading of tensor storage data from the pickle stream.
+        /// </summary>
+        /// <param name="pid">The persistent ID object containing storage information.</param>
+        /// <returns>An <see cref="NCTensorStream"/> object representing the tensor data.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the persistent load data is invalid or archive entry is not found.</exception>
+        /// <exception cref="NotImplementedException">Thrown when an unknown persistent ID type is encountered.</exception>
+        protected override object persistentLoad(object pid)
         {
-            return storage switch
+            if (pid is not object[] array)
+                throw new InvalidOperationException("Invalid persistent load data");
+
+            if ((string)array[0] != "storage")
+                throw new NotImplementedException("Unknown persistent id loaded");
+
+            string name = ((ClassDictConstructor)array[1]).name;
+            string archiveKey = (string)array[2];
+            var scalarType = GetScalarTypeFromStorageName(name);
+
+            var entry = _archive.Entries
+                .Select((e, i) => (Entry: e, Index: i))
+                .FirstOrDefault(e => e.Entry.FullName.EndsWith("data/" + archiveKey));
+
+            if (entry.Entry == null)
+                throw new InvalidOperationException($"Archive entry not found: data/{archiveKey}");
+
+            return new NCTensorStream
             {
-                "DoubleStorage" => torch.float64,
-                "FloatStorage" => torch.@float,
-                "HalfStorage" => torch.half,
-                "LongStorage" => torch.@long,
-                "IntStorage" => torch.@int,
-                "ShortStorage" => torch.int16,
-                "CharStorage" => torch.int8,
-                "ByteStorage" => torch.uint8,
-                "BoolStorage" => torch.@bool,
-                "BFloat16Storage" => torch.bfloat16,
-                "ComplexDoubleStorage" => torch.cdouble,
-                "ComplexFloatStorage" => torch.cfloat,
-                _ => throw new NotImplementedException(),
+                ArchiveIndex = entry.Index,
+                ArchiveEntry = entry.Entry,
+                DType = scalarType,
+                SkipTensorRead = _skipTensorRead
             };
         }
+    }
 
-        private class DACOrderedDict : Hashtable
+    /// <summary>
+    /// Maps PyTorch storage type names to corresponding TorchSharp scalar types.
+    /// </summary>
+    /// <param name="storage">The PyTorch storage type name (e.g., "FloatStorage", "DoubleStorage").</param>
+    /// <returns>The corresponding <see cref="torch.ScalarType"/>.</returns>
+    /// <exception cref="NotImplementedException">Thrown when the storage type is not supported.</exception>
+    private static torch.ScalarType GetScalarTypeFromStorageName(string storage)
+    {
+        return storage switch
         {
-            public Dictionary<string, Tensor> AsTensorDict()
-            {
-                var dict = new Dictionary<string, Tensor>();
-                foreach (DictionaryEntry entry in this)
-                {
-                    var key = entry.Key?.ToString() ??
-                        throw new InvalidOperationException("Null key in state dict");
+            "DoubleStorage" => torch.float64,
+            "FloatStorage" => torch.@float,
+            "HalfStorage" => torch.half,
+            "LongStorage" => torch.@long,
+            "IntStorage" => torch.@int,
+            "ShortStorage" => torch.int16,
+            "CharStorage" => torch.int8,
+            "ByteStorage" => torch.uint8,
+            "BoolStorage" => torch.@bool,
+            "BFloat16Storage" => torch.bfloat16,
+            "ComplexDoubleStorage" => torch.cdouble,
+            "ComplexFloatStorage" => torch.cfloat,
+            _ => throw new NotImplementedException(),
+        };
+    }
 
-                    if (entry.Value is Tensor tensor)
-                    {
-                        dict[key] = tensor;
-                    }
-                    else if (entry.Value is NCTensorConstructorArgs args)
-                    {
-                        dict[key] = args.ReadTensorFromStream();
-                    }
+    /// <summary>
+    /// Represents an ordered dictionary specifically designed for DAC model state dictionaries.
+    /// Extends <see cref="Hashtable"/> to provide tensor conversion capabilities.
+    /// </summary>
+    private class DACOrderedDict : Hashtable
+    {
+        /// <summary>
+        /// Converts the ordered dictionary to a strongly-typed dictionary of tensors.
+        /// </summary>
+        /// <returns>A dictionary with string keys and <see cref="Tensor"/> values.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when a key is null in the state dictionary.</exception>
+        public Dictionary<string, Tensor> AsTensorDict()
+        {
+            var dict = new Dictionary<string, Tensor>();
+            foreach (DictionaryEntry entry in this)
+            {
+                var key = entry.Key?.ToString() ??
+                    throw new InvalidOperationException("Null key in state dict");
+
+                if (entry.Value is Tensor tensor)
+                {
+                    dict[key] = tensor;
                 }
-                return dict;
-            }
-
-            public void __setstate__(Hashtable state)
-            {
-                ArgumentNullException.ThrowIfNull(state);
-
-                foreach (DictionaryEntry entry in state)
+                else if (entry.Value is NCTensorConstructorArgs args)
                 {
-                    this[entry.Key] = entry.Value;
-                }
-            }
-        }
-
-        internal class NCTensorConstructorArgs
-        {
-            private bool _alreadyRead;
-
-            public int ArchiveIndex { get; init; }
-
-            public Stream Data { get; init; }
-
-            public torch.ScalarType DType { get; init; }
-
-            public int StorageOffset { get; init; }
-
-            public long[] Shape { get; init; }
-
-            public long[] Stride { get; init; }
-
-            public bool RequiresGrad { get; init; }
-
-            public torch.Tensor ReadTensorFromStream()
-            {
-                if (_alreadyRead)
-                {
-                    throw new InvalidOperationException("The tensor has already been constructed, cannot read tensor twice.");
-                }
-
-                torch.Tensor tensor = torch.empty(Shape, DType, torch.CPU).as_strided(Shape, Stride, StorageOffset);
-                tensor.ReadBytesFromStream(Data);
-                Data.Close();
-                _alreadyRead = true;
-                return tensor;
-            }
-        }
-
-        private class NCTensorStream
-        {
-            public int ArchiveIndex { get; init; }
-
-            public ZipArchiveEntry ArchiveEntry { get; init; }
-
-            public torch.ScalarType DType { get; init; }
-
-            public bool SkipTensorRead { get; init; }
-        }
-
-        private class NCTensorObjectConstructor : IObjectConstructor
-        {
-            public object construct(object[] args)
-            {
-                NCTensorStream tensorStream = (NCTensorStream)args[0];
-                NCTensorConstructorArgs tensorConstructorArgs = new NCTensorConstructorArgs
-                {
-                    ArchiveIndex = tensorStream.ArchiveIndex,
-                    Data = tensorStream.ArchiveEntry.Open(),
-                    DType = tensorStream.DType,
-                    StorageOffset = (int)args[1],
-                    Shape = ((IEnumerable<object>)(object[])args[2]).Select((Func<object, long>)((object i) => (int)i)).ToArray(),
-                    Stride = ((IEnumerable<object>)(object[])args[3]).Select((Func<object, long>)((object i) => (int)i)).ToArray(),
-                    RequiresGrad = (bool)args[4]
-                };
-                if (!tensorStream.SkipTensorRead)
-                {
-                    return tensorConstructorArgs.ReadTensorFromStream();
-                }
-
-                return tensorConstructorArgs;
-            }
-        }
-
-        private class DACDictConstructor : IObjectConstructor
-        {
-            public object construct(object[] args)
-            {
-                return new DACOrderedDict();
-            }
-        }
-
-        static DACUnpickler()
-        {
-            // Register our custom constructors
-            Unpickler.registerConstructor("torch._utils", "_rebuild_tensor", new NCTensorObjectConstructor());
-            Unpickler.registerConstructor("torch._utils", "_rebuild_tensor_v2", new NCTensorObjectConstructor());
-            Unpickler.registerConstructor("collections", "OrderedDict", new DACDictConstructor());
-        }
-
-        public static DACWeights LoadFromFile(string path)
-        {
-            if (string.IsNullOrEmpty(path))
-                throw new ArgumentNullException(nameof(path));
-
-            if (!File.Exists(path))
-                throw new FileNotFoundException("Model weights file not found", path);
-
-            // Handle different file formats
-            if (path.EndsWith(".safetensors"))
-                return LoadFromSafetensors(path);
-
-            return LoadFromStream(File.OpenRead(path));
-        }
-
-        public static DACWeights LoadFromSafetensors(string path)
-        {
-            var stateDict = Safetensors.LoadStateDict(path) ??
-                throw new InvalidOperationException("Failed to load safetensor weights");
-
-            // Convert weights using dynamic converter
-            var normalizedDict = StateDictNameConverter.ConvertStateDict(stateDict, fromSafetensor: true);
-            return new DACWeights(normalizedDict);
-        }
-
-        public static DACWeights LoadFromStream(Stream stream, bool leaveOpen = false)
-        {
-            ArgumentNullException.ThrowIfNull(stream);
-
-            if (!stream.CanRead)
-                throw new ArgumentException("Stream must be readable", nameof(stream));
-
-            // Verify zip magic number
-            byte[] magic = new byte[4];
-            if (stream.Read(magic, 0, 4) != 4)
-                throw new InvalidOperationException("Failed to read magic number");
-
-            stream.Seek(0, SeekOrigin.Begin);
-
-            if (magic[0] != 0x50 || magic[1] != 0x4B || magic[2] != 0x03 || magic[3] != 0x04)
-            {
-                throw new InvalidOperationException(
-                    "Invalid .pth file format - must be a zip archive. File may be corrupted or saved in legacy format.");
-            }
-
-            using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen);
-            var entry = archive.Entries.FirstOrDefault(e => e.Name.EndsWith("data.pkl")) ??
-                throw new InvalidOperationException("Model archive missing data.pkl");
-
-            var unpickler = new CustomDACUnpickler(archive);
-            var result = unpickler.load(entry.Open()) as Hashtable ??
-                throw new InvalidOperationException("Failed to unpickle model data");
-
-            // Extract state dict
-            var stateDict = result["state_dict"] as DACOrderedDict ??
-                throw new InvalidOperationException("Missing or invalid state_dict");
-            var weights = stateDict.AsTensorDict();
-
-            // Extract metadata
-            var metadata = result["metadata"] as Hashtable ??
-                throw new InvalidOperationException("Missing or invalid metadata");
-            var convertedMetadata = ConvertToMetadataDict(metadata);
-
-            return new DACWeights(weights, convertedMetadata);
-        }
-
-        public static (DACWeights Weights, DACConfig Config) LoadWithConfig(string path)
-        {
-            var weights = LoadFromFile(path);
-            var config = CreateConfigFromMetadata(weights);
-            return (weights, config);
-        }
-
-        public static DACConfig CreateConfigFromMetadata(DACWeights weights)
-        {
-            ArgumentNullException.ThrowIfNull(weights);
-            if (weights.Metadata is null || weights.Metadata.Count == 0)
-            {
-                return new DACConfig();
-            }
-
-            return new DACConfig
-            {
-                SampleRate = GetMetadataValue<int>(weights.Metadata, "sampling_rate", 44100),
-                EncoderDim = GetMetadataValue<int>(weights.Metadata, "encoder_dim", 64),
-                LatentDim = GetMetadataValue<int?>(weights.Metadata, "latent_dim"),
-                EncoderRates = GetMetadataValue<int[]>(weights.Metadata, "encoder_rates", [2, 4, 8, 8]),
-                DecoderRates = GetMetadataValue<int[]>(weights.Metadata, "decoder_rates", [8, 8, 4, 2]),
-                DecoderDim = GetMetadataValue<int>(weights.Metadata, "decoder_dim", 1536),
-                NumCodebooks = GetMetadataValue<int>(weights.Metadata, "n_codebooks", 9),
-                CodebookSize = GetMetadataValue<int>(weights.Metadata, "codebook_size", 4096),
-                CodebookDim = GetMetadataValue<int>(weights.Metadata, "codebook_dim", 8),
-                QuantizerDropout = GetMetadataValue<float>(weights.Metadata, "quantizer_dropout", 0.0f),
-            };
-        }
-
-        private static Dictionary<string, object> ConvertToMetadataDict(Hashtable metadata)
-        {
-            var dict = new Dictionary<string, object>();
-
-            foreach (DictionaryEntry entry in metadata)
-            {
-                var key = entry.Key?.ToString();
-                var value = entry.Value;
-
-                if (key == null)
-                {
-                    continue;
-                }
-
-                if (value is Hashtable subTable)
-                {
-                    dict[key] = ConvertToMetadataDict(subTable);
-                }
-                else
-                {
-                    dict[key] = value;
+                    dict[key] = args.ReadTensorFromStream();
                 }
             }
-
             return dict;
         }
 
-        private static T GetMetadataValue<T>(
-                Dictionary<string, object> metadata,
-                string key,
-                T defaultValue = default)
+        /// <summary>
+        /// Sets the state of the ordered dictionary from a hashtable, typically called during unpickling.
+        /// </summary>
+        /// <param name="state">The hashtable containing the state data to restore.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="state"/> is null.</exception>
+        public void __setstate__(Hashtable state)
         {
-            ArgumentNullException.ThrowIfNull(metadata);
+            ArgumentNullException.ThrowIfNull(state);
 
-            if (string.IsNullOrEmpty(key))
-                throw new ArgumentNullException(nameof(key));
-
-            if (!metadata.TryGetValue(key, out var value))
-                return defaultValue;
-
-            try
+            foreach (DictionaryEntry entry in state)
             {
-                if (typeof(T).IsArray && value is Array arr)
+                this[entry.Key] = entry.Value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Contains the arguments and data needed to construct a tensor from a stream during unpickling.
+    /// </summary>
+    internal class NCTensorConstructorArgs
+    {
+        private bool _alreadyRead;
+
+        /// <summary>
+        /// Gets or sets the index of the archive entry containing the tensor data.
+        /// </summary>
+        public int ArchiveIndex { get; init; }
+
+        /// <summary>
+        /// Gets or sets the stream containing the tensor's raw data.
+        /// </summary>
+        public Stream Data { get; init; }
+
+        /// <summary>
+        /// Gets or sets the scalar type of the tensor data.
+        /// </summary>
+        public torch.ScalarType DType { get; init; }
+
+        /// <summary>
+        /// Gets or sets the storage offset for the tensor data.
+        /// </summary>
+        public int StorageOffset { get; init; }
+
+        /// <summary>
+        /// Gets or sets the shape dimensions of the tensor.
+        /// </summary>
+        public long[] Shape { get; init; }
+
+        /// <summary>
+        /// Gets or sets the stride values for the tensor.
+        /// </summary>
+        public long[] Stride { get; init; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the tensor requires gradient computation.
+        /// </summary>
+        public bool RequiresGrad { get; init; }
+
+        /// <summary>
+        /// Reads the tensor data from the stream and constructs a <see cref="torch.Tensor"/>.
+        /// </summary>
+        /// <returns>A new <see cref="torch.Tensor"/> instance with the data loaded from the stream.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when attempting to read the tensor more than once.</exception>
+        public torch.Tensor ReadTensorFromStream()
+        {
+            if (_alreadyRead)
+            {
+                throw new InvalidOperationException("The tensor has already been constructed, cannot read tensor twice.");
+            }
+
+            torch.Tensor tensor = torch.empty(Shape, DType, torch.CPU).as_strided(Shape, Stride, StorageOffset);
+            tensor.ReadBytesFromStream(Data);
+            Data.Close();
+            _alreadyRead = true;
+            return tensor;
+        }
+    }
+
+    /// <summary>
+    /// Represents a stream reference to tensor data within a ZIP archive.
+    /// </summary>
+    private class NCTensorStream
+    {
+        /// <summary>
+        /// Gets or sets the index of the archive entry.
+        /// </summary>
+        public int ArchiveIndex { get; init; }
+
+        /// <summary>
+        /// Gets or sets the ZIP archive entry containing the tensor data.
+        /// </summary>
+        public ZipArchiveEntry ArchiveEntry { get; init; }
+
+        /// <summary>
+        /// Gets or sets the scalar type of the tensor data.
+        /// </summary>
+        public torch.ScalarType DType { get; init; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether tensor reading should be skipped.
+        /// </summary>
+        public bool SkipTensorRead { get; init; }
+    }
+
+    /// <summary>
+    /// Object constructor that creates tensor objects during the unpickling process.
+    /// Implements <see cref="IObjectConstructor"/> to handle PyTorch tensor reconstruction.
+    /// </summary>
+    private class NCTensorObjectConstructor : IObjectConstructor
+    {
+        /// <summary>
+        /// Constructs a tensor object from the provided arguments during unpickling.
+        /// </summary>
+        /// <param name="args">Array containing tensor construction arguments including stream, offset, shape, stride, and gradient requirements.</param>
+        /// <returns>Either a <see cref="torch.Tensor"/> or <see cref="NCTensorConstructorArgs"/> depending on the skip tensor read setting.</returns>
+        public object construct(object[] args)
+        {
+            NCTensorStream tensorStream = (NCTensorStream)args[0];
+            NCTensorConstructorArgs tensorConstructorArgs = new NCTensorConstructorArgs
+            {
+                ArchiveIndex = tensorStream.ArchiveIndex,
+                Data = tensorStream.ArchiveEntry.Open(),
+                DType = tensorStream.DType,
+                StorageOffset = (int)args[1],
+                Shape = ((IEnumerable<object>)(object[])args[2]).Select((Func<object, long>)((object i) => (int)i)).ToArray(),
+                Stride = ((IEnumerable<object>)(object[])args[3]).Select((Func<object, long>)((object i) => (int)i)).ToArray(),
+                RequiresGrad = (bool)args[4]
+            };
+            if (!tensorStream.SkipTensorRead)
+            {
+                return tensorConstructorArgs.ReadTensorFromStream();
+            }
+
+            return tensorConstructorArgs;
+        }
+    }
+
+    /// <summary>
+    /// Object constructor that creates <see cref="DACOrderedDict"/> instances during unpickling.
+    /// Implements <see cref="IObjectConstructor"/> to handle ordered dictionary reconstruction.
+    /// </summary>
+    private class DACDictConstructor : IObjectConstructor
+    {
+        /// <summary>
+        /// Constructs a new <see cref="DACOrderedDict"/> instance.
+        /// </summary>
+        /// <param name="args">Construction arguments (currently unused).</param>
+        /// <returns>A new <see cref="DACOrderedDict"/> instance.</returns>
+        public object construct(object[] args)
+        {
+            return new DACOrderedDict();
+        }
+    }
+
+    /// <summary>
+    /// Static constructor that registers custom object constructors with the unpickler.
+    /// </summary>
+    static DACUnpickler()
+    {
+        // Register our custom constructors
+        Unpickler.registerConstructor("torch._utils", "_rebuild_tensor", new NCTensorObjectConstructor());
+        Unpickler.registerConstructor("torch._utils", "_rebuild_tensor_v2", new NCTensorObjectConstructor());
+        Unpickler.registerConstructor("collections", "OrderedDict", new DACDictConstructor());
+    }
+
+    /// <summary>
+    /// Loads DAC model weights from a file, supporting both pickle (.pth) and safetensors formats.
+    /// </summary>
+    /// <param name="path">The file path to the model weights.</param>
+    /// <returns>A <see cref="DACWeights"/> object containing the loaded model weights and metadata.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="path"/> is null or empty.</exception>
+    /// <exception cref="FileNotFoundException">Thrown when the specified file does not exist.</exception>
+    public static DACWeights LoadFromFile(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+            throw new ArgumentNullException(nameof(path));
+
+        if (!File.Exists(path))
+            throw new FileNotFoundException("Model weights file not found", path);
+
+        // Handle different file formats
+        if (path.EndsWith(".safetensors"))
+            return LoadFromSafetensors(path);
+
+        return LoadFromStream(File.OpenRead(path));
+    }
+
+    /// <summary>
+    /// Loads DAC model weights from a safetensors format file.
+    /// </summary>
+    /// <param name="path">The file path to the safetensors file.</param>
+    /// <returns>A <see cref="DACWeights"/> object containing the loaded model weights.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the safetensors file cannot be loaded.</exception>
+    public static DACWeights LoadFromSafetensors(string path)
+    {
+        var previousDevice = torch.get_default_device();
+        set_default_device(CPU);
+        var stateDict = Safetensors.LoadStateDict(path) ??
+            throw new InvalidOperationException("Failed to load safetensor weights");
+
+        var normalizedDict = StateDictNameConverter.ConvertStateDict(stateDict, fromSafetensor: true);
+
+        if (previousDevice != CPU)
+        {
+            set_default_device(previousDevice);
+        }
+        return new DACWeights(normalizedDict);
+    }
+
+    /// <summary>
+    /// Loads DAC model weights from a stream containing pickle data in ZIP format.
+    /// </summary>
+    /// <param name="stream">The stream containing the model data.</param>
+    /// <param name="leaveOpen">If true, the stream will not be closed after reading.</param>
+    /// <returns>A <see cref="DACWeights"/> object containing the loaded model weights and metadata.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="stream"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when the stream is not readable.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the file format is invalid or required data is missing.</exception>
+    public static DACWeights LoadFromStream(Stream stream, bool leaveOpen = false)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        if (!stream.CanRead)
+            throw new ArgumentException("Stream must be readable", nameof(stream));
+
+        // Verify zip magic number
+        byte[] magic = new byte[4];
+        if (stream.Read(magic, 0, 4) != 4)
+            throw new InvalidOperationException("Failed to read magic number");
+
+        stream.Seek(0, SeekOrigin.Begin);
+
+        if (magic[0] != 0x50 || magic[1] != 0x4B || magic[2] != 0x03 || magic[3] != 0x04)
+        {
+            throw new InvalidOperationException(
+                "Invalid .pth file format - must be a zip archive. File may be corrupted or saved in legacy format.");
+        }
+
+        using var archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen);
+        var entry = archive.Entries.FirstOrDefault(e => e.Name.EndsWith("data.pkl")) ??
+            throw new InvalidOperationException("Model archive missing data.pkl");
+
+        var unpickler = new CustomDACUnpickler(archive);
+        var result = unpickler.load(entry.Open()) as Hashtable ??
+            throw new InvalidOperationException("Failed to unpickle model data");
+
+        // Extract state dict
+        var stateDict = result["state_dict"] as DACOrderedDict ??
+            throw new InvalidOperationException("Missing or invalid state_dict");
+        var weights = stateDict.AsTensorDict();
+
+        // Extract metadata
+        var metadata = result["metadata"] as Hashtable ??
+            throw new InvalidOperationException("Missing or invalid metadata");
+        var convertedMetadata = ConvertToMetadataDict(metadata);
+
+        return new DACWeights(weights, convertedMetadata);
+    }
+
+    /// <summary>
+    /// Loads DAC model weights and creates a configuration from the embedded metadata.
+    /// </summary>
+    /// <param name="path">The file path to the model weights.</param>
+    /// <returns>A tuple containing the loaded <see cref="DACWeights"/> and the generated <see cref="DACConfig"/>.</returns>
+    public static (DACWeights Weights, DACConfig Config) LoadWithConfig(string path)
+    {
+        var weights = LoadFromFile(path);
+        var config = CreateConfigFromMetadata(weights);
+        return (weights, config);
+    }
+
+    /// <summary>
+    /// Creates a DAC configuration object from the metadata contained in the loaded weights.
+    /// </summary>
+    /// <param name="weights">The DAC weights containing metadata to extract configuration from.</param>
+    /// <returns>A <see cref="DACConfig"/> object with parameters extracted from the metadata, or default values if metadata is missing.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="weights"/> is null.</exception>
+    public static DACConfig CreateConfigFromMetadata(DACWeights weights)
+    {
+        ArgumentNullException.ThrowIfNull(weights);
+        if (weights.Metadata is null || weights.Metadata.Count == 0)
+        {
+            return new DACConfig();
+        }
+
+        return new DACConfig
+        {
+            SampleRate = GetMetadataValue<int>(weights.Metadata, "sampling_rate", 44100),
+            EncoderDim = GetMetadataValue<int>(weights.Metadata, "encoder_dim", 64),
+            LatentDim = GetMetadataValue<int?>(weights.Metadata, "latent_dim"),
+            EncoderRates = GetMetadataValue<int[]>(weights.Metadata, "encoder_rates", [2, 4, 8, 8]),
+            DecoderRates = GetMetadataValue<int[]>(weights.Metadata, "decoder_rates", [8, 8, 4, 2]),
+            DecoderDim = GetMetadataValue<int>(weights.Metadata, "decoder_dim", 1536),
+            NumCodebooks = GetMetadataValue<int>(weights.Metadata, "n_codebooks", 9),
+            CodebookSize = GetMetadataValue<int>(weights.Metadata, "codebook_size", 4096),
+            CodebookDim = GetMetadataValue<int>(weights.Metadata, "codebook_dim", 8),
+            QuantizerDropout = GetMetadataValue<float>(weights.Metadata, "quantizer_dropout", 0.0f),
+        };
+    }
+
+    /// <summary>
+    /// Converts a hashtable containing metadata to a strongly-typed dictionary.
+    /// </summary>
+    /// <param name="metadata">The hashtable containing the metadata to convert.</param>
+    /// <returns>A dictionary with string keys and object values, with nested hashtables recursively converted.</returns>
+    private static Dictionary<string, object> ConvertToMetadataDict(Hashtable metadata)
+    {
+        var dict = new Dictionary<string, object>();
+
+        foreach (DictionaryEntry entry in metadata)
+        {
+            var key = entry.Key?.ToString();
+            var value = entry.Value;
+
+            if (key == null)
+            {
+                continue;
+            }
+
+            if (value is Hashtable subTable)
+            {
+                dict[key] = ConvertToMetadataDict(subTable);
+            }
+            else
+            {
+                dict[key] = value;
+            }
+        }
+
+        return dict;
+    }
+
+    /// <summary>
+    /// Retrieves a strongly-typed value from the metadata dictionary with optional default value.
+    /// </summary>
+    /// <typeparam name="T">The type to convert the metadata value to.</typeparam>
+    /// <param name="metadata">The metadata dictionary to search.</param>
+    /// <param name="key">The key to look up in the metadata.</param>
+    /// <param name="defaultValue">The default value to return if the key is not found or conversion fails.</param>
+    /// <returns>The converted value if found and successfully converted, otherwise the default value.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="metadata"/> is null or <paramref name="key"/> is null or empty.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when type conversion fails.</exception>
+    private static T GetMetadataValue<T>(
+            Dictionary<string, object> metadata,
+            string key,
+            T defaultValue = default)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        if (string.IsNullOrEmpty(key))
+            throw new ArgumentNullException(nameof(key));
+
+        if (!metadata.TryGetValue(key, out var value))
+            return defaultValue;
+
+        try
+        {
+            if (typeof(T).IsArray && value is Array arr)
+            {
+                var elementType = typeof(T).GetElementType();
+                var converted = Array.CreateInstance(elementType, arr.Length);
+                for (int i = 0; i < arr.Length; i++)
                 {
-                    var elementType = typeof(T).GetElementType();
-                    var converted = Array.CreateInstance(elementType, arr.Length);
-                    for (int i = 0; i < arr.Length; i++)
-                    {
-                        converted.SetValue(Convert.ChangeType(arr.GetValue(i), elementType), i);
-                    }
-                    return (T)(object)converted;
+                    converted.SetValue(Convert.ChangeType(arr.GetValue(i), elementType), i);
                 }
+                return (T)(object)converted;
+            }
 
-                return (T)Convert.ChangeType(value, typeof(T));
-            }
-            catch (Exception ex)
-            {
-                throw new InvalidOperationException(
-                    $"Failed to convert metadata value for key '{key}' to type {typeof(T).Name}", ex);
-            }
+            return (T)Convert.ChangeType(value, typeof(T));
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"Failed to convert metadata value for key '{key}' to type {typeof(T).Name}", ex);
         }
     }
 }

--- a/NeuralCodecs.Torch/Config/DAC/DACWeights.cs
+++ b/NeuralCodecs.Torch/Config/DAC/DACWeights.cs
@@ -1,18 +1,17 @@
 ﻿using static TorchSharp.torch;
 
-namespace NeuralCodecs.Torch.Config.DAC
-{
-    public class DACWeights
-    {
-        public Dictionary<string, Tensor> StateDict { get; }
-        public Dictionary<string, object>? Metadata { get; }
+namespace NeuralCodecs.Torch.Config.DAC;
 
-        public DACWeights(
-            Dictionary<string, Tensor> stateDict,
-            Dictionary<string, object>? metadata = null)
-        {
-            StateDict = stateDict ?? throw new ArgumentNullException(nameof(stateDict));
-            Metadata = metadata;
-        }
+public class DACWeights
+{
+    public Dictionary<string, Tensor> StateDict { get; }
+    public Dictionary<string, object>? Metadata { get; }
+
+    public DACWeights(
+        Dictionary<string, Tensor> stateDict,
+        Dictionary<string, object>? metadata = null)
+    {
+        StateDict = stateDict ?? throw new ArgumentNullException(nameof(stateDict));
+        Metadata = metadata;
     }
 }

--- a/NeuralCodecs.Torch/Config/DAC/StateDictNameConverter.cs
+++ b/NeuralCodecs.Torch/Config/DAC/StateDictNameConverter.cs
@@ -345,7 +345,6 @@ public class StateDictNameConverter
         var baseParts = safetensorKey.Split(new[] { ".weight", ".bias", ".alpha" }, StringSplitOptions.None);
         var baseKey = baseParts[0];
 
-        Debug.WriteLine($"Base key: {baseKey}");
         if (keyMap.TryGetValue(baseKey, out var torchKey))
         {
             // Reattach the appropriate suffix

--- a/NeuralCodecs.Torch/Config/Dia/AudioSlowdownMode.cs
+++ b/NeuralCodecs.Torch/Config/Dia/AudioSlowdownMode.cs
@@ -1,0 +1,17 @@
+namespace NeuralCodecs.Torch.Config.Dia;
+
+/// <summary>
+/// Audio slowdown mode options for Dia TTS.
+/// </summary>
+public enum AudioSlowdownMode
+{
+    /// <summary>
+    /// Use a fixed static slowdown factor.
+    /// </summary>
+    Static,
+
+    /// <summary>
+    /// Use dynamic slowdown based on text length.
+    /// </summary>
+    Dynamic
+}

--- a/NeuralCodecs.Torch/Config/Dia/AudioSpeedCorrectionMethod.cs
+++ b/NeuralCodecs.Torch/Config/Dia/AudioSpeedCorrectionMethod.cs
@@ -1,0 +1,32 @@
+namespace NeuralCodecs.Torch.Config.Dia;
+
+/// <summary>
+/// Audio processing method options for speed and pitch adjustment
+/// </summary>
+public enum AudioSpeedCorrectionMethod
+{
+    /// <summary>
+    /// No speed correction applied.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Use TorchSharp-based linear interpolation
+    /// </summary>
+    TorchSharp,
+
+    /// <summary>
+    /// Hybrid speed correction combining TorchSharp and NAudio methods
+    /// </summary>
+    Hybrid,
+
+    /// <summary>
+    /// Use NAudio resampling for speed correction
+    /// </summary>
+    NAudioResampling,
+
+    /// <summary>
+    /// Create seperate outputs using all available methods (for comparison/testing)
+    /// </summary>
+    All
+}

--- a/NeuralCodecs.Torch/Config/Dia/ComputeDtype.cs
+++ b/NeuralCodecs.Torch/Config/Dia/ComputeDtype.cs
@@ -1,0 +1,22 @@
+namespace NeuralCodecs.Torch.Config.Dia;
+
+/// <summary>
+/// Compute data types for model inference.
+/// </summary>
+public enum ComputeDtype
+{
+    /// <summary>
+    /// 32-bit floating point
+    /// </summary>
+    Float32,
+
+    /// <summary>
+    /// 16-bit floating point
+    /// </summary>
+    Float16,
+
+    /// <summary>
+    /// Brain floating point (16-bit)
+    /// </summary>
+    BFloat16
+}

--- a/NeuralCodecs.Torch/Config/Dia/ComputeDtypeExtensions.cs
+++ b/NeuralCodecs.Torch/Config/Dia/ComputeDtypeExtensions.cs
@@ -1,0 +1,25 @@
+using static TorchSharp.torch;
+
+namespace NeuralCodecs.Torch.Config.Dia;
+
+/// <summary>
+/// Extensions for ComputeDtype enum.
+/// </summary>
+public static class ComputeDtypeExtensions
+{
+    /// <summary>
+    /// Converts ComputeDtype to TorchSharp ScalarType.
+    /// </summary>
+    /// <param name="dtype">Compute data type</param>
+    /// <returns>TorchSharp ScalarType</returns>
+    public static ScalarType ToTorchDtype(this ComputeDtype dtype)
+    {
+        return dtype switch
+        {
+            ComputeDtype.Float32 => ScalarType.Float32,
+            ComputeDtype.Float16 => ScalarType.Float16,
+            ComputeDtype.BFloat16 => ScalarType.BFloat16,
+            _ => throw new ArgumentException($"Unsupported compute dtype: {dtype}")
+        };
+    }
+}

--- a/NeuralCodecs.Torch/Config/Dia/DataConfig.cs
+++ b/NeuralCodecs.Torch/Config/Dia/DataConfig.cs
@@ -1,0 +1,113 @@
+using System.Text.Json.Serialization;
+
+namespace NeuralCodecs.Torch.Config.Dia;
+
+/// <summary>
+/// Configuration for data loading and preprocessing.
+/// </summary>
+public class DataConfig
+{
+    /// <summary>
+    /// Maximum length of text sequences (must be multiple of 128).
+    /// </summary>
+    [JsonPropertyName("text_length")]
+    public int TextLength { get; set; } = 1024;
+
+    /// <summary>
+    /// Maximum length of audio sequences (must be multiple of 128).
+    /// </summary>
+    [JsonPropertyName("audio_length")]
+    public int AudioLength { get; set; } = 3072;
+
+    /// <summary>
+    /// Number of audio channels.
+    /// </summary>
+    [JsonPropertyName("channels")]
+    public int Channels { get; set; } = 9;
+
+    /// <summary>
+    /// Value used for padding text sequences.
+    /// </summary>
+    [JsonPropertyName("text_pad_value")]
+    public int TextPadValue { get; set; } = 0;
+
+    /// <summary>
+    /// Value representing the end of audio sequences.
+    /// </summary>
+    [JsonPropertyName("audio_eos_value")]
+    public int AudioEosValue { get; set; } = 1024;
+
+    /// <summary>
+    /// Value representing the beginning of audio sequences.
+    /// </summary>
+    [JsonPropertyName("audio_bos_value")]
+    public int AudioBosValue { get; set; } = 1026;
+
+    /// <summary>
+    /// Value used for padding audio sequences.
+    /// </summary>
+    [JsonPropertyName("audio_pad_value")]
+    public int AudioPadValue { get; set; } = 1025;
+
+    /// <summary>
+    /// List of delay values for each audio channel.
+    /// </summary>
+    [JsonPropertyName("delay_pattern")]
+    public int[] DelayPattern { get; set; } = new[] { 0, 8, 9, 10, 11, 12, 13, 14, 15 };
+
+    /// <summary>
+    /// Creates a new DataConfig instance.
+    /// </summary>
+    /// <param name="textLength">Maximum length of text sequences (must be multiple of 128).</param>
+    /// <param name="audioLength">Maximum length of audio sequences (must be multiple of 128).</param>
+    /// <param name="channels">Number of audio channels.</param>
+    /// <param name="textPadValue">Value used for padding text sequences.</param>
+    /// <param name="audioEosValue">Value representing the end of audio sequences.</param>
+    /// <param name="audioBosValue">Value representing the beginning of audio sequences.</param>
+    /// <param name="audioPadValue">Value used for padding audio sequences.</param>
+    /// <param name="delayPattern">List of delay values for each audio channel.</param>
+    public DataConfig(
+        int textLength = 1024,
+        int audioLength = 3072,
+        int channels = 9,
+        int textPadValue = 0,
+        int audioEosValue = 1024,
+        int audioPadValue = 1025,
+        int audioBosValue = 1026,
+        int[] delayPattern = null)
+    {
+        // Validate and adjust textLength to be a multiple of 128
+        int adjustedTextLength = (textLength + 127) / 128 * 128;
+        if (textLength <= 0)
+        {
+            throw new ArgumentException("TextLength must be positive", nameof(textLength));
+        }
+
+        // Validate and adjust audioLength to be a multiple of 128
+        int adjustedAudioLength = (audioLength + 127) / 128 * 128;
+        if (audioLength <= 0)
+        {
+            throw new ArgumentException("AudioLength must be positive", nameof(audioLength));
+        }
+
+        // Validate channels
+        if (channels <= 0)
+        {
+            throw new ArgumentException("Channels must be positive", nameof(channels));
+        }
+
+        TextLength = adjustedTextLength;
+        AudioLength = adjustedAudioLength;
+        Channels = channels;
+        TextPadValue = textPadValue;
+        AudioEosValue = audioEosValue;
+        AudioPadValue = audioPadValue;
+        AudioBosValue = audioBosValue;
+        DelayPattern = delayPattern ?? new[] { 0, 8, 9, 10, 11, 12, 13, 14, 15 };
+
+        if (Channels != DelayPattern.Length)
+        {
+            throw new ArgumentException($"Number of channels ({Channels}) must match delay pattern length ({DelayPattern.Length})");
+        }
+    }
+}

--- a/NeuralCodecs.Torch/Config/Dia/DecoderConfig.cs
+++ b/NeuralCodecs.Torch/Config/Dia/DecoderConfig.cs
@@ -1,0 +1,102 @@
+using System.Text.Json.Serialization;
+
+namespace NeuralCodecs.Torch.Config.Dia;
+
+/// <summary>
+/// Configuration for the decoder component of the Dia model.
+/// </summary>
+public class DecoderConfig
+{
+    /// <summary>
+    /// Number of transformer layers.
+    /// </summary>
+    [JsonPropertyName("n_layer")]
+    public int NLayer { get; set; } = 18;
+
+    /// <summary>
+    /// Embedding dimension.
+    /// </summary>
+    [JsonPropertyName("n_embd")]
+    public int NEmbedding { get; set; } = 2048;
+
+    /// <summary>
+    /// Hidden dimension size in the MLP layers.
+    /// </summary>
+    [JsonPropertyName("n_hidden")]
+    public int NHidden { get; set; } = 8192;
+
+    /// <summary>
+    /// Number of query heads for grouped-query self-attention.
+    /// </summary>
+    [JsonPropertyName("gqa_query_heads")]
+    public int GqaQueryHeads { get; set; } = 16;
+
+    /// <summary>
+    /// Number of key/value heads for grouped-query self-attention.
+    /// </summary>
+    [JsonPropertyName("kv_heads")]
+    public int KvHeads { get; set; } = 4;
+
+    /// <summary>
+    /// Dimension per query head for grouped-query self-attention.
+    /// </summary>
+    [JsonPropertyName("gqa_head_dim")]
+    public int GqaHeadDim { get; set; } = 128;
+
+    /// <summary>
+    /// Number of query heads for cross-attention.
+    /// </summary>
+    [JsonPropertyName("cross_query_heads")]
+    public int CrossQueryHeads { get; set; } = 16;
+
+    /// <summary>
+    /// Dimension per cross-attention head.
+    /// </summary>
+    [JsonPropertyName("cross_head_dim")]
+    public int CrossHeadDim { get; set; } = 128;
+
+    /// <summary>
+    /// Creates a new DecoderConfig instance.
+    /// </summary>
+    /// <param name="nLayer">Number of transformer layers.</param>
+    /// <param name="nEmbedding">Embedding dimension.</param>
+    /// <param name="nHidden">Hidden dimension size in the MLP layers.</param>
+    /// <param name="gqaQueryHeads">Number of query heads for grouped-query self-attention.</param>
+    /// <param name="kvHeads">Number of key/value heads for grouped-query self-attention.</param>
+    /// <param name="gqaHeadDim">Dimension per query head for grouped-query self-attention.</param>
+    /// <param name="crossQueryHeads">Number of query heads for cross-attention.</param>
+    /// <param name="crossHeadDim">Dimension per cross-attention head.</param>
+    public DecoderConfig(
+        int nLayer = 18,
+        int nEmbedding = 2048,
+        int nHidden = 8192,
+        int gqaQueryHeads = 16,
+        int kvHeads = 4,
+        int gqaHeadDim = 128,
+        int crossQueryHeads = 16,
+        int crossHeadDim = 128)
+    {
+        if (nLayer <= 0) throw new ArgumentOutOfRangeException(nameof(nLayer), "Must be greater than 0");
+        if (nEmbedding <= 0) throw new ArgumentOutOfRangeException(nameof(nEmbedding), "Must be greater than 0");
+        if (nHidden <= 0) throw new ArgumentOutOfRangeException(nameof(nHidden), "Must be greater than 0");
+        if (gqaQueryHeads <= 0) throw new ArgumentOutOfRangeException(nameof(gqaQueryHeads), "Must be greater than 0");
+        if (kvHeads <= 0) throw new ArgumentOutOfRangeException(nameof(kvHeads), "Must be greater than 0");
+        if (gqaHeadDim <= 0) throw new ArgumentOutOfRangeException(nameof(gqaHeadDim), "Must be greater than 0");
+        if (crossQueryHeads <= 0) throw new ArgumentOutOfRangeException(nameof(crossQueryHeads), "Must be greater than 0");
+        if (crossHeadDim <= 0) throw new ArgumentOutOfRangeException(nameof(crossHeadDim), "Must be greater than 0");
+
+        if (gqaQueryHeads % kvHeads != 0)
+        {
+            throw new ArgumentException($"GQA query heads ({gqaQueryHeads}) must be divisible by KV heads ({kvHeads})");
+        }
+
+        NLayer = nLayer;
+        NEmbedding = nEmbedding;
+        NHidden = nHidden;
+        GqaQueryHeads = gqaQueryHeads;
+        KvHeads = kvHeads;
+        GqaHeadDim = gqaHeadDim;
+        CrossQueryHeads = crossQueryHeads;
+        CrossHeadDim = crossHeadDim;
+    }
+}

--- a/NeuralCodecs.Torch/Config/Dia/DiaConfig.cs
+++ b/NeuralCodecs.Torch/Config/Dia/DiaConfig.cs
@@ -1,0 +1,231 @@
+using NeuralCodecs.Core.Configuration;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NeuralCodecs.Torch.Config.Dia;
+
+/// <summary>
+/// The main configuration for Dia TTS, including model, data processing, and device settings.
+/// </summary>
+public class DiaConfig : IModelConfig
+{
+    /// <summary>
+    /// Data loading and processing configuration.
+    /// </summary>
+    [JsonPropertyName("data")]
+    public DataConfig Data { get; set; } = new DataConfig();
+
+    /// <summary>
+    /// Model architecture configuration.
+    /// </summary>
+    [JsonPropertyName("model")]
+    public DiaModelConfig Model { get; set; } = new DiaModelConfig();
+
+    /// <summary>
+    /// Configuration version string.
+    /// </summary>
+    [JsonPropertyName("version")]
+    public string Version { get; set; } = "0.1";
+
+    /// <summary>
+    /// Path to the Dia model.
+    /// </summary>
+    [JsonIgnore]
+    public string ModelPath { get; set; } = "nari-labs/Dia-1.6B";
+
+    /// <summary>
+    /// Path to the DAC model for audio decoding.
+    /// </summary>
+    [JsonIgnore]
+    public string DACModelPath { get; set; } = "descript/dac_44khz";
+
+    /// <summary>
+    /// CFG (Classifier-Free Guidance) scale for generation.
+    /// </summary>
+    [JsonIgnore]
+    public float CfgScale { get; set; } = 3.0f;
+
+    /// <summary>
+    /// Temperature for sampling during generation.
+    /// </summary>
+    [JsonIgnore]
+    public float Temperature { get; set; } = 1.3f;
+
+    /// <summary>
+    /// Top-p (nucleus) sampling parameter.
+    /// </summary>
+    [JsonIgnore]
+    public float TopP { get; set; } = 0.95f;
+
+    /// <summary>
+    /// Scale factor for classifier-free guidance.
+    /// </summary>
+    [JsonIgnore]
+    public int CfgFilterTopK { get; set; } = 45;
+
+    /// <summary>
+    /// Enable verbose logging during inference.
+    /// </summary>
+    [JsonIgnore]
+    public bool Verbose { get; set; } = false;
+
+    /// <summary>
+    /// Compute data type for model operations.
+    /// </summary>
+    [JsonIgnore]
+    public ComputeDtype ComputeDtype { get; set; } = ComputeDtype.Float32;
+
+    /// <summary>
+    /// Device configuration for model execution.
+    /// </summary>
+    [JsonIgnore]
+    public DeviceConfiguration Device { get; set; } = DeviceConfiguration.CUDA();
+
+    /// <summary>
+    /// DAC sample rate for audio synthesis.
+    /// </summary>
+    [JsonIgnore]
+    public int SampleRate { get; set; } = 44100;
+
+    /// <summary>
+    /// Whether to load the DAC model for decoding.
+    /// </summary>
+    [JsonIgnore]
+    public bool LoadDACModel { get; set; } = true;
+
+    /// <summary>
+    /// Model architecture identifier.
+    /// </summary>
+    [JsonIgnore]
+    public string Architecture { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Additional metadata for the configuration.
+    /// </summary>
+    [JsonIgnore]
+    public IDictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// Random seed for reproducible generation.
+    /// </summary>
+    [JsonIgnore]
+    public int? Seed { get; set; } = null;
+
+    /// <summary>
+    /// Audio slowdown mode configuration.
+    /// </summary>
+    [JsonIgnore]
+    public AudioSlowdownMode SlowdownMode { get; set; } = AudioSlowdownMode.Dynamic;
+
+    /// <summary>
+    /// Static slowdown factor when using static mode (e.g., 0.95 for 5% slowdown).
+    /// </summary>
+    [JsonIgnore]
+    public float StaticSlowdownFactor { get; set; } = 0.95f;
+
+    /// <summary>
+    /// Audio processing method for speed adjustment.
+    /// </summary>
+    [JsonIgnore]
+    public AudioSpeedCorrectionMethod SpeedCorrectionMethod { get; set; } = AudioSpeedCorrectionMethod.Hybrid;
+
+    /// <summary>
+    /// Text length threshold for dynamic slowdown to start (in characters).
+    /// </summary>
+    [JsonIgnore]
+    public float DynamicSlowdownStartLength { get; set; } = 400f;
+
+    /// <summary>
+    /// Text length where maximum dynamic slowdown is reached (in characters).
+    /// </summary>
+    [JsonIgnore]
+    public float DynamicSlowdownMaxLength { get; set; } = 750f;
+
+    /// <summary>
+    /// Maximum slowdown percentage for dynamic mode (0.20 = 20% slowdown).
+    /// </summary>
+    [JsonIgnore]
+    public float DynamicSlowdownMaxPercent { get; set; } = 0.20f;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiaConfig"/> class.
+    /// </summary>
+    /// <param name="model">Model architecture configuration.</param>
+    /// <param name="data">Data loading and processing configuration.</param>
+    /// <param name="version">Configuration version string.</param>
+    public DiaConfig(
+        DiaModelConfig model,
+        DataConfig data,
+        string version = "0.1")
+    {
+        Model = model ?? new DiaModelConfig();
+        Data = data ?? new DataConfig();
+        Version = version;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DiaConfig"/> class.
+    /// </summary>
+    /// <remarks>This constructor initializes the <see cref="Model"/> and <see cref="Data"/> properties with
+    /// their default configurations.</remarks>
+    public DiaConfig()
+    {
+        Model = new DiaModelConfig();
+        Data = new DataConfig();
+    }
+
+    /// <summary>
+    /// Save the current configuration instance to a JSON file.
+    /// </summary>
+    /// <param name="path">The target file path to save the configuration.</param>
+    public void Save(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            throw new ArgumentException("Path cannot be null or empty.", nameof(path));
+        }
+        if (Path.GetDirectoryName(path) is not string outPath)
+        {
+            throw new ArgumentException("Directory does not exist", nameof(path));
+        }
+        Directory.CreateDirectory(outPath);
+        var options = new JsonSerializerOptions
+        {
+            WriteIndented = true
+        };
+        string json = JsonSerializer.Serialize(this, options);
+        File.WriteAllText(path, json);
+    }
+
+    /// <summary>
+    /// Load and validate a Dia configuration from a JSON file.
+    /// </summary>
+    /// <param name="path">The path to the configuration file.</param>
+    /// <returns>A validated DiaConfig instance if the file exists and is valid, otherwise null.</returns>
+    public static DiaConfig Load(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Configuration file not found: {path}");
+        }
+
+        if (!Path.GetExtension(path).Equals(".json", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"Configuration must be a .json file: {path}");
+        }
+
+        try
+        {
+            string json = File.ReadAllText(path);
+            var options = new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+            return JsonSerializer.Deserialize<DiaConfig>(json, options)!;
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException($"Failed to parse configuration file: {ex.Message}", ex);
+        }
+    }
+}

--- a/NeuralCodecs.Torch/Config/Dia/DiaModelConfig.cs
+++ b/NeuralCodecs.Torch/Config/Dia/DiaModelConfig.cs
@@ -1,0 +1,103 @@
+using System.Text.Json.Serialization;
+
+namespace NeuralCodecs.Torch.Config.Dia;
+
+/// <summary>
+/// Main configuration container for the Dia model architecture.
+/// </summary>
+public class DiaModelConfig
+{
+    /// <summary>
+    /// Configuration for the encoder component.
+    /// </summary>
+    [JsonPropertyName("encoder")]
+    public EncoderConfig Encoder { get; set; } = new EncoderConfig();
+
+    /// <summary>
+    /// Configuration for the decoder component.
+    /// </summary>
+    [JsonPropertyName("decoder")]
+    public DecoderConfig Decoder { get; set; } = new DecoderConfig();
+
+    /// <summary>
+    /// Size of the source (text) vocabulary.
+    /// </summary>
+    [JsonPropertyName("src_vocab_size")]
+    public int SrcVocabSize { get; set; } = 256;
+
+    /// <summary>
+    /// Size of the target (audio code) vocabulary.
+    /// </summary>
+    [JsonPropertyName("tgt_vocab_size")]
+    public int TgtVocabSize { get; set; } = 1028;
+
+    /// <summary>
+    /// Dropout probability applied within the model.
+    /// </summary>
+    [JsonPropertyName("dropout")]
+    public float Dropout { get; set; } = 0.0f;
+
+    /// <summary>
+    /// Epsilon value for normalization layers (e.g., LayerNorm).
+    /// </summary>
+    [JsonPropertyName("normalization_layer_epsilon")]
+    public float NormalizationLayerEpsilon { get; set; } = 1.0e-5f;
+
+    /// <summary>
+    /// Data type for model weights (e.g., "float32", "bfloat16").
+    /// </summary>
+    [JsonPropertyName("weight_dtype")]
+    public string WeightDtype { get; set; } = "float32";
+
+    /// <summary>
+    /// Minimum timescale for Rotary Positional Embeddings (RoPE).
+    /// </summary>
+    [JsonPropertyName("rope_min_timescale")]
+    public int RopeMinTimescale { get; set; } = 1;
+
+    /// <summary>
+    /// Maximum timescale for Rotary Positional Embeddings (RoPE).
+    /// </summary>
+    [JsonPropertyName("rope_max_timescale")]
+    public int RopeMaxTimescale { get; set; } = 10_000;
+
+    /// <summary>
+    /// Creates a new DiaModelConfig instance.
+    /// </summary>
+    /// <param name="encoder">Configuration for the encoder component.</param>
+    /// <param name="decoder">Configuration for the decoder component.</param>
+    /// <param name="srcVocabSize">Size of the source (text) vocabulary.</param>
+    /// <param name="tgtVocabSize">Size of the target (audio code) vocabulary.</param>
+    /// <param name="dropout">Dropout probability applied within the model.</param>
+    /// <param name="normalizationLayerEpsilon">Epsilon value for normalization layers.</param>
+    /// <param name="weightDtype">Data type for model weights.</param>
+    /// <param name="ropeMinTimescale">Minimum timescale for Rotary Positional Embeddings.</param>
+    /// <param name="ropeMaxTimescale">Maximum timescale for Rotary Positional Embeddings.</param>
+    public DiaModelConfig(
+        EncoderConfig encoder = null,
+        DecoderConfig decoder = null,
+        int srcVocabSize = 256,
+        int tgtVocabSize = 1028,
+        float dropout = 0.0f,
+        float normalizationLayerEpsilon = 1.0e-5f,
+        string weightDtype = "float32",
+        int ropeMinTimescale = 1,
+        int ropeMaxTimescale = 10_000)
+    {
+        Encoder = encoder ?? new();
+        Decoder = decoder ?? new();
+
+        if (srcVocabSize <= 0) throw new ArgumentOutOfRangeException(nameof(srcVocabSize), "Must be greater than 0");
+        if (tgtVocabSize <= 0) throw new ArgumentOutOfRangeException(nameof(tgtVocabSize), "Must be greater than 0");
+        if (dropout < 0.0f || dropout >= 1.0f) throw new ArgumentOutOfRangeException(nameof(dropout), "Must be in range [0, 1)");
+        if (normalizationLayerEpsilon <= 0.0f) throw new ArgumentOutOfRangeException(nameof(normalizationLayerEpsilon), "Must be greater than 0");
+
+        SrcVocabSize = srcVocabSize;
+        TgtVocabSize = tgtVocabSize;
+        Dropout = dropout;
+        NormalizationLayerEpsilon = normalizationLayerEpsilon;
+        WeightDtype = weightDtype;
+        RopeMinTimescale = ropeMinTimescale;
+        RopeMaxTimescale = ropeMaxTimescale;
+    }
+}

--- a/NeuralCodecs.Torch/Config/Dia/EncoderConfig.cs
+++ b/NeuralCodecs.Torch/Config/Dia/EncoderConfig.cs
@@ -1,0 +1,62 @@
+using System.Text.Json.Serialization;
+
+namespace NeuralCodecs.Torch.Config.Dia;
+
+/// <summary>
+/// Configuration for the encoder component of the Dia model.
+/// </summary>
+public class EncoderConfig
+{
+    /// <summary>
+    /// Number of transformer layers.
+    /// </summary>
+    [JsonPropertyName("n_layer")]
+    public int NLayer { get; set; } = 12;
+
+    /// <summary>
+    /// Embedding dimension.
+    /// </summary>
+    [JsonPropertyName("n_embd")]
+    public int NEmbedding { get; set; } = 1024;
+
+    /// <summary>
+    /// Hidden dimension size in the MLP layers.
+    /// </summary>
+    [JsonPropertyName("n_hidden")]
+    public int NHidden { get; set; } = 4096;
+
+    /// <summary>
+    /// Number of attention heads.
+    /// </summary>
+    [JsonPropertyName("n_head")]
+    public int NHead { get; set; } = 16;
+
+    /// <summary>
+    /// Dimension per attention head.
+    /// </summary>
+    [JsonPropertyName("head_dim")]
+    public int HeadDim { get; set; } = 128;
+
+    /// <summary>
+    /// Creates a new EncoderConfig instance.
+    /// </summary>
+    /// <param name="nLayer">Number of transformer layers.</param>
+    /// <param name="nEmbedding">Embedding dimension.</param>
+    /// <param name="nHidden">Hidden dimension size in the MLP layers.</param>
+    /// <param name="nHead">Number of attention heads.</param>
+    /// <param name="headDim">Dimension per attention head.</param>
+    public EncoderConfig(int nLayer = 12, int nEmbedding = 1024, int nHidden = 4096, int nHead = 16, int headDim = 128)
+    {
+        if (nLayer <= 0) throw new ArgumentOutOfRangeException(nameof(nLayer), "Must be greater than 0");
+        if (nEmbedding <= 0) throw new ArgumentOutOfRangeException(nameof(nEmbedding), "Must be greater than 0");
+        if (nHidden <= 0) throw new ArgumentOutOfRangeException(nameof(nHidden), "Must be greater than 0");
+        if (nHead <= 0) throw new ArgumentOutOfRangeException(nameof(nHead), "Must be greater than 0");
+        if (headDim <= 0) throw new ArgumentOutOfRangeException(nameof(headDim), "Must be greater than 0");
+
+        NLayer = nLayer;
+        NEmbedding = nEmbedding;
+        NHidden = nHidden;
+        NHead = nHead;
+        HeadDim = headDim;
+    }
+}

--- a/NeuralCodecs.Torch/Config/SNAC/SNACValidator.cs
+++ b/NeuralCodecs.Torch/Config/SNAC/SNACValidator.cs
@@ -5,145 +5,144 @@ using NeuralCodecs.Torch.Utils;
 using TorchSharp;
 using DeviceType = NeuralCodecs.Core.Configuration.DeviceType;
 
-namespace NeuralCodecs.Torch.Config.SNAC
+namespace NeuralCodecs.Torch.Config.SNAC;
+
+/// <summary>
+/// Validates SNAC (Simplified Neural Audio Codec) configuration and model implementations.
+/// Ensures both the configuration parameters and the model's runtime behavior meet expected requirements.
+/// </summary>
+public class SNACValidator : IModelValidator<SNACConfig>
 {
     /// <summary>
-    /// Validates SNAC (Simplified Neural Audio Codec) configuration and model implementations.
-    /// Ensures both the configuration parameters and the model's runtime behavior meet expected requirements.
+    /// Validates the SNAC configuration parameters for correctness and consistency.
     /// </summary>
-    public class SNACValidator : IModelValidator<SNACConfig>
+    /// <param name="config">The SNAC configuration to validate</param>
+    /// <returns>A ValidationResult indicating success or containing error messages if validation failed</returns>
+    public ValidationResult ValidateConfig(SNACConfig config)
     {
-        /// <summary>
-        /// Validates the SNAC configuration parameters for correctness and consistency.
-        /// </summary>
-        /// <param name="config">The SNAC configuration to validate</param>
-        /// <returns>A ValidationResult indicating success or containing error messages if validation failed</returns>
-        public ValidationResult ValidateConfig(SNACConfig config)
+        var errors = new List<string>();
+
+        if (config.SampleRate <= 0)
+            errors.Add($"Invalid sampling rate: {config.SampleRate}");
+
+        if (config.EncoderDim <= 0)
+            errors.Add($"Invalid encoder dimension: {config.EncoderDim}");
+
+        if (config.DecoderDim <= 0)
+            errors.Add($"Invalid decoder dimension: {config.DecoderDim}");
+
+        if (config.EncoderRates.IsNullOrEmpty())
+            errors.Add("Missing encoder rates");
+        else if (config.EncoderRates.Any(r => r <= 0))
+            errors.Add("Invalid encoder rate values");
+
+        if (config.DecoderRates.IsNullOrEmpty())
+            errors.Add("Missing decoder rates");
+        else if (config.DecoderRates.Any(r => r <= 0))
+            errors.Add("Invalid decoder rate values");
+
+        if (config.AttnWindowSize <= 0)
+            errors.Add($"Invalid attention window size: {config.AttnWindowSize}");
+
+        if (config.CodebookSize <= 0)
+            errors.Add($"Invalid codebook size: {config.CodebookSize}");
+
+        if (config.CodebookDim <= 0)
+            errors.Add($"Invalid codebook dimension: {config.CodebookDim}");
+
+        if (config.VQStrides.IsNullOrEmpty())
+            errors.Add("Missing VQ strides");
+        else if (config.VQStrides.Any(s => s <= 0))
+            errors.Add("Invalid VQ stride values");
+
+        return errors.Count > 0
+            ? ValidationResult.Failed(errors.ToArray())
+            : ValidationResult.Success();
+    }
+
+    /// <summary>
+    /// Validates the SNAC model's runtime behavior by performing test encoding and decoding operations.
+    /// </summary>
+    /// <param name="model">The neural codec model to validate</param>
+    /// <param name="config">The configuration associated with the model</param>
+    /// <returns>A ValidationResult indicating success or containing error messages if validation failed</returns>
+    public async Task<ValidationResult> ValidateModel(INeuralCodec model, SNACConfig config)
+    {
+        if (model is not Models.SNAC snacModel)
         {
-            var errors = new List<string>();
-
-            if (config.SampleRate <= 0)
-                errors.Add($"Invalid sampling rate: {config.SampleRate}");
-
-            if (config.EncoderDim <= 0)
-                errors.Add($"Invalid encoder dimension: {config.EncoderDim}");
-
-            if (config.DecoderDim <= 0)
-                errors.Add($"Invalid decoder dimension: {config.DecoderDim}");
-
-            if (config.EncoderRates.IsNullOrEmpty())
-                errors.Add("Missing encoder rates");
-            else if (config.EncoderRates.Any(r => r <= 0))
-                errors.Add("Invalid encoder rate values");
-
-            if (config.DecoderRates.IsNullOrEmpty())
-                errors.Add("Missing decoder rates");
-            else if (config.DecoderRates.Any(r => r <= 0))
-                errors.Add("Invalid decoder rate values");
-
-            if (config.AttnWindowSize <= 0)
-                errors.Add($"Invalid attention window size: {config.AttnWindowSize}");
-
-            if (config.CodebookSize <= 0)
-                errors.Add($"Invalid codebook size: {config.CodebookSize}");
-
-            if (config.CodebookDim <= 0)
-                errors.Add($"Invalid codebook dimension: {config.CodebookDim}");
-
-            if (config.VQStrides.IsNullOrEmpty())
-                errors.Add("Missing VQ strides");
-            else if (config.VQStrides.Any(s => s <= 0))
-                errors.Add("Invalid VQ stride values");
-
-            return errors.Count > 0
-                ? ValidationResult.Failed(errors.ToArray())
-                : ValidationResult.Success();
+            return ValidationResult.Failed($"Expected SNAC model but got {model.GetType().Name}");
         }
 
-        /// <summary>
-        /// Validates the SNAC model's runtime behavior by performing test encoding and decoding operations.
-        /// </summary>
-        /// <param name="model">The neural codec model to validate</param>
-        /// <param name="config">The configuration associated with the model</param>
-        /// <returns>A ValidationResult indicating success or containing error messages if validation failed</returns>
-        public async Task<ValidationResult> ValidateModel(INeuralCodec model, SNACConfig config)
+        var errors = new List<string>();
+
+        try
         {
-            if (model is not Models.SNAC snacModel)
+            using var scope = torch.NewDisposeScope();
+            // Create 100ms of audio at the model's sample rate for quick validation
+            var sampleLength = (int)(config.SampleRate * 0.1);
+            var input = torch.randn(1, 1, sampleLength);
+
+            if (config.Device?.Type is DeviceType.CUDA)
             {
-                return ValidationResult.Failed($"Expected SNAC model but got {model.GetType().Name}");
+                input = input.cuda();
             }
 
-            var errors = new List<string>();
-
-            try
+            await Task.Run(() =>
             {
-                using var scope = torch.NewDisposeScope();
-                // Create 100ms of audio at the model's sample rate for quick validation
-                var sampleLength = (int)(config.SampleRate * 0.1);
-                var input = torch.randn(1, 1, sampleLength);
-
-                if (config.Device?.Type is DeviceType.CUDA)
+                using (torch.inference_mode())
                 {
-                    input = input.cuda();
-                }
-
-                await Task.Run(() =>
-                {
-                    using (torch.inference_mode())
+                    // Validate encoding
+                    var codes = snacModel.Encode(input);
+                    var cCount = codes.Count();
+                    if (codes == null || cCount == 0)
                     {
-                        // Validate encoding
-                        var codes = snacModel.Encode(input);
-                        var cCount = codes.Count();
-                        if (codes == null || cCount == 0)
-                        {
-                            errors.Add("Model encoding failed - no codes produced");
-                            return;
-                        }
-
-                        // Validate number of codebooks matches config
-                        if (cCount != config.VQStrides.Length)
-                        {
-                            errors.Add($"Model produced {cCount} codebooks but config specifies {config.VQStrides.Length}");
-                            return;
-                        }
-
-                        // Validate decoding
-                        var output = snacModel.Decode(codes);
-
-                        // Check output dimensions
-                        if (output.dim() != 3)
-                        {
-                            errors.Add($"Model output has incorrect number of dimensions: {output.dim()} (expected 3)");
-                            return;
-                        }
-
-                        if (output.size(0) != 1 || output.size(1) != 1)
-                        {
-                            errors.Add($"Model output has incorrect batch/channel dimensions: {output.shape}");
-                            return;
-                        }
-
-                        // Validate output length is reasonable
-                        var expectedLength = sampleLength;
-                        var actualLength = output.size(-1);
-                        var lengthDiff = Math.Abs(expectedLength - actualLength);
-
-                        // Allow for some padding/alignment differences but not too large
-                        if (lengthDiff > config.SampleRate * 0.01) // More than 1% difference
-                        {
-                            errors.Add($"Model output length {actualLength} differs significantly from expected {expectedLength}");
-                        }
+                        errors.Add("Model encoding failed - no codes produced");
+                        return;
                     }
-                });
-            }
-            catch (Exception ex)
-            {
-                errors.Add($"Model validation failed: {ex.Message}");
-            }
 
-            return errors.Count > 0
-                ? ValidationResult.Failed(errors.ToArray())
-                : ValidationResult.Success();
+                    // Validate number of codebooks matches config
+                    if (cCount != config.VQStrides.Length)
+                    {
+                        errors.Add($"Model produced {cCount} codebooks but config specifies {config.VQStrides.Length}");
+                        return;
+                    }
+
+                    // Validate decoding
+                    var output = snacModel.Decode(codes);
+
+                    // Check output dimensions
+                    if (output.dim() != 3)
+                    {
+                        errors.Add($"Model output has incorrect number of dimensions: {output.dim()} (expected 3)");
+                        return;
+                    }
+
+                    if (output.size(0) != 1 || output.size(1) != 1)
+                    {
+                        errors.Add($"Model output has incorrect batch/channel dimensions: {output.shape}");
+                        return;
+                    }
+
+                    // Validate output length is reasonable
+                    var expectedLength = sampleLength;
+                    var actualLength = output.size(-1);
+                    var lengthDiff = Math.Abs(expectedLength - actualLength);
+
+                    // Allow for some padding/alignment differences but not too large
+                    if (lengthDiff > config.SampleRate * 0.01) // More than 1% difference
+                    {
+                        errors.Add($"Model output length {actualLength} differs significantly from expected {expectedLength}");
+                    }
+                }
+            });
         }
+        catch (Exception ex)
+        {
+            errors.Add($"Model validation failed: {ex.Message}");
+        }
+
+        return errors.Count > 0
+            ? ValidationResult.Failed(errors.ToArray())
+            : ValidationResult.Success();
     }
 }

--- a/NeuralCodecs.Torch/Models/DAC.cs
+++ b/NeuralCodecs.Torch/Models/DAC.cs
@@ -209,7 +209,6 @@ public class DAC : Module<Tensor, Dictionary<string, Tensor>>, INeuralCodec
         using var scope = torch.NewDisposeScope();
         using var inferenceScope = torch.inference_mode();
 
-
         // Convert input audio data to tensor
         var inputTensor = torch.tensor(audioData, dtype: torch.float32, _device)
                               .reshape(1, 1, -1)

--- a/NeuralCodecs.Torch/Models/DAC.cs
+++ b/NeuralCodecs.Torch/Models/DAC.cs
@@ -30,13 +30,13 @@ public class DAC : Module<Tensor, Dictionary<string, Tensor>>, INeuralCodec
     private readonly int _sampleRate;
     private readonly int _hopLength;
     private torch.Device _device => TorchUtils.GetDevice(_config.Device);
-
     private readonly Encoder encoder;
     private readonly ResidualVectorQuantizer quantizer;
     private readonly Decoder decoder;
 
     private DACConfig _config;
     public IModelConfig Config => _config;
+    public ResidualVectorQuantizer Quantizer => quantizer;
 
     /// <summary>
     /// Initializes a new instance of the DAC model.
@@ -93,6 +93,19 @@ public class DAC : Module<Tensor, Dictionary<string, Tensor>>, INeuralCodec
     }
 
     /// <summary>
+    /// Decodes quantized codes back into audio waveform.
+    /// This method reconstructs audio from previously encoded discrete codes using the quantizer's decoder.
+    /// </summary>
+    /// <param name="codes">Tensor containing the quantized codes to decode. Shape should be compatible with the quantizer's expected input format.</param>
+    /// <returns>Reconstructed audio tensor in the original audio domain.</returns>
+    public Tensor FromCodes(Tensor codes)
+    {
+        using var inference = torch.inference_mode();
+        var (audio, _, _) = quantizer.FromCodes(codes);
+        return audio.MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
     /// Initializes the model's weights using Kaiming normal initialization.
     /// </summary>
     private void InitializeWeights()
@@ -103,13 +116,17 @@ public class DAC : Module<Tensor, Dictionary<string, Tensor>>, INeuralCodec
             {
                 init.kaiming_normal_(conv.weight);
                 if (conv.bias is not null)
+                {
                     init.zeros_(conv.bias);
+                }
             }
             else if (module is ConvTranspose1d convT)
             {
                 init.kaiming_normal_(convT.weight);
                 if (convT.bias is not null)
+                {
                     init.zeros_(convT.bias);
+                }
             }
         }
     }
@@ -147,9 +164,10 @@ public class DAC : Module<Tensor, Dictionary<string, Tensor>>, INeuralCodec
         Encode(Tensor audioData, int? nQuantizers = null, int? sampleRate = null)
     {
         using var scope = NewDisposeScope();
+        using var inferenceScope = torch.inference_mode();
 
-        audioData = Preprocess(audioData, sampleRate);
-        var z = encoder.forward(audioData);
+        var processed = Preprocess(audioData, sampleRate);
+        var z = encoder.forward(processed);
         var (zQ, codes, latents, commitmentLoss, codebookLoss) =
             quantizer.forward(z, nQuantizers);
 
@@ -161,17 +179,22 @@ public class DAC : Module<Tensor, Dictionary<string, Tensor>>, INeuralCodec
             codebookLoss.MoveToOuterDisposeScope()
         );
     }
+
+    /// <summary>
+    /// Encodes the input audio data through the encoder and quantizer.
+    /// </summary>
+    /// <param name="audioData">Input audio tensor.</param>
+    /// <returns>Quantized audio tensor.</returns>
     public Tensor EncodeAudio(Tensor audioData)
     {
         using var scope = NewDisposeScope();
+        using var inferenceScope = torch.inference_mode();
 
-        audioData = Preprocess(audioData, _sampleRate);
-        var z = encoder.forward(audioData);
-        var (zQ, _, _, _, _) =
-            quantizer.forward(z, null);
+        var processed = Preprocess(audioData, _sampleRate);
+        var z = encoder.forward(processed);
+        var (zQ, _, _, _, _) = quantizer.forward(z, null);
 
         return zQ.MoveToOuterDisposeScope();
-        
     }
 
     /// <summary>
@@ -184,6 +207,8 @@ public class DAC : Module<Tensor, Dictionary<string, Tensor>>, INeuralCodec
         ArgumentNullException.ThrowIfNull(audioData);
 
         using var scope = torch.NewDisposeScope();
+        using var inferenceScope = torch.inference_mode();
+
 
         // Convert input audio data to tensor
         var inputTensor = torch.tensor(audioData, dtype: torch.float32, _device)
@@ -241,10 +266,11 @@ public class DAC : Module<Tensor, Dictionary<string, Tensor>>, INeuralCodec
         int? nQuantizers)
     {
         using var scope = NewDisposeScope();
-        var (z, codes, latents, commitmentLoss, codebookLoss) = Encode(audioData, sampleRate, nQuantizers);
+
+        var (z, codes, latents, commitmentLoss, codebookLoss) = Encode(audioData, nQuantizers, sampleRate);
         var audio = Decode(z);
 
-        return new Dictionary<string, Tensor> //TODO NAME
+        return new Dictionary<string, Tensor>
         {
             ["audio"] = audio.MoveToOuterDisposeScope(),
             ["z"] = z.MoveToOuterDisposeScope(),
@@ -311,14 +337,6 @@ public class DAC : Module<Tensor, Dictionary<string, Tensor>>, INeuralCodec
         base.Dispose(disposing);
     }
 
-    private static string GetRelativePath(string fullPath, string basePath)
-    {
-        var fullUri = new Uri(fullPath);
-        var baseUri = new Uri(basePath);
-        var relativeUri = baseUri.MakeRelativeUri(fullUri);
-        return Uri.UnescapeDataString(relativeUri.ToString());
-    }
-
     /// <summary>
     /// Loads the model weights from the specified file path.
     /// </summary>
@@ -328,10 +346,21 @@ public class DAC : Module<Tensor, Dictionary<string, Tensor>>, INeuralCodec
     public void LoadWeights(string path)
     {
         if (!File.Exists(path))
+        {
             throw new FileNotFoundException($"DAC weights not found at {path}");
+        }
 
         try
         {
+            set_default_device(CPU);
+            if (_device != CPU)
+            {
+                using (no_grad())
+                {
+                    this.to(CPU);
+                }
+            }
+
             switch (FileUtils.DetectFileType(path))
             {
                 case ModelFileType.Checkpoint:
@@ -343,6 +372,15 @@ public class DAC : Module<Tensor, Dictionary<string, Tensor>>, INeuralCodec
                     this.load_state_dict(modelDict.StateDict);
                     _config ??= config;
                     break;
+            }
+
+            if (_device != CPU)
+            {
+                using (no_grad())
+                {
+                    this.to(_device);
+                    set_default_device(_device);
+                }
             }
         }
         catch (Exception ex) when (ex is not (FileNotFoundException or InvalidOperationException))

--- a/NeuralCodecs.Torch/Models/Dia.cs
+++ b/NeuralCodecs.Torch/Models/Dia.cs
@@ -1,0 +1,1256 @@
+// Copyright (c) Dillion Lowry
+//
+// This file contains a C# port of Dia, originally developed by Nari Labs.
+// 
+// Original work: Copyright (c) Nari Labs
+// Original source: https://github.com/nari-labs/dia
+// Original license: Apache License 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+using NeuralCodecs.Core;
+using NeuralCodecs.Core.Configuration;
+using NeuralCodecs.Core.Utils;
+using NeuralCodecs.Torch.Config.DAC;
+using NeuralCodecs.Torch.Config.Dia;
+using NeuralCodecs.Torch.Modules.Dia;
+using NeuralCodecs.Torch.Utils;
+using System.Diagnostics;
+using System.Text;
+using TorchSharp;
+using static TorchSharp.torch;
+using AudioUtils = NeuralCodecs.Torch.Modules.Dia.AudioUtils;
+
+namespace NeuralCodecs.Torch.Models;
+
+/// <summary>
+/// Dia model for text-to-speech generation.
+/// </summary>
+public class Dia : INeuralCodec
+{
+    #region Constants
+
+    /// <summary>
+    /// Default sample rate for audio processing
+    /// </summary>
+    private const int DefaultSampleRate = 44100;
+
+    /// <summary>
+    /// Maximum valid codebook index value
+    /// </summary>
+    private const long MaxValidCodebookIndex = 1023L;
+
+    /// <summary>
+    /// Minimum valid codebook index value
+    /// </summary>
+    private const long MinValidCodebookIndex = 0L;
+
+    #endregion Constants
+
+    private readonly ScalarType _computeDtype;
+    private readonly DiaConfig _config;
+    private readonly Device _device;
+    private DiaModel _model;
+    private DAC? _dacModel;
+    private bool _disposed;
+    private bool _verbose;
+
+    /// <summary>
+    /// Gets or sets the audio processing method to use for speed and pitch adjustments
+    /// </summary>
+    public AudioSpeedCorrectionMethod AudioCorrectionMethod
+    {
+        get => _config.SpeedCorrectionMethod;
+        set => _config.SpeedCorrectionMethod = value;
+    }
+
+    IModelConfig INeuralCodec.Config => _config;
+
+    /// <summary>
+    /// Gets the device used for computation.
+    /// </summary>
+    public Device Device => _device;
+
+    /// <summary>
+    /// Gets the underlying DiaModel instance.
+    /// </summary>
+    public DiaModel Model => _model;
+
+    #region Constructor and Factory Methods
+
+    /// <summary>
+    /// Initializes a new instance of the Dia class.
+    /// </summary>
+    /// <param name="config">Configuration settings for the Dia model</param>
+    public Dia(DiaConfig config)
+    {
+        _config = config ?? throw new ArgumentNullException(nameof(config));
+        _computeDtype = config.ComputeDtype.ToTorchDtype();
+        _device = TorchUtils.GetDevice(config.Device);
+        _verbose = config.Verbose;
+        if (config.Seed is not null)
+        {
+            SetSeed(config.Seed.Value);
+        }
+
+        _model = new DiaModel(_config, _computeDtype, _device);
+        _model.to(_device);
+        _model.eval();
+
+        if (config.LoadDACModel)
+        {
+            LoadDacModel(_config.DACModelPath);
+        }
+    }
+
+    /// <summary>
+    /// Loads the DAC model for audio decoding.
+    /// </summary>
+    public void LoadDacModel(string dacPath)
+        => LoadDacModelAsync(dacPath).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Loads the DAC model for audio decoding.
+    /// </summary>
+    public async Task LoadDacModelAsync(string dacPath, DACConfig? config = null)
+    {
+        try
+        {
+            _dacModel = await NeuralCodecs.CreateDACAsync(dacPath, config ?? DACConfig.DAC44kHz);
+            _dacModel.to(_device);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Failed to load DAC model", ex);
+        }
+    }
+
+    /// <summary>
+    /// Loads weights from the specified path.
+    /// </summary>
+    /// <param name="path">Path to the weights file</param>
+    public void LoadWeights(string path) => _model.LoadWeights(path);
+
+#pragma warning disable IDE1006 // Naming Styles
+
+    /// <summary>
+    /// Sets the model to evaluation mode.
+    /// </summary>
+    public void eval() => _model.eval();
+
+    /// <summary>
+    /// Sets the model to training mode.
+    /// </summary>
+
+    public void train() => _model.train();
+
+#pragma warning restore IDE1006 // Naming Styles
+
+    #endregion Constructor and Factory Methods
+
+    #region Text Processing Methods
+
+    private static int CountOccurrences(ReadOnlySpan<byte> source, int sourceLength, ReadOnlySpan<byte> pattern)
+    {
+        int count = 0;
+        int pos = 0;
+
+        while (pos <= sourceLength - pattern.Length)
+        {
+            if (source.Slice(pos, pattern.Length).SequenceEqual(pattern))
+            {
+                count++;
+                pos += pattern.Length;
+            }
+            else
+            {
+                pos++;
+            }
+        }
+
+        return count;
+    }
+
+    private static int ReplaceInPlace(ReadOnlySpan<byte> source, int sourceLength,
+    ReadOnlySpan<byte> pattern, ReadOnlySpan<byte> replacement, out byte[] output)
+    {
+        output = null!;
+
+        if (pattern.Length == replacement.Length)
+        {
+            int pos = 0;
+            while (pos <= sourceLength - pattern.Length)
+            {
+                if (source.Slice(pos, pattern.Length).SequenceEqual(pattern))
+                {
+                    if (output == null)
+                    {
+                        output = new byte[sourceLength];
+                        source.Slice(0, pos).CopyTo(output);
+                    }
+                    replacement.CopyTo(output.AsSpan(pos));
+                    pos += pattern.Length;
+                }
+                else
+                {
+                    if (output != null)
+                    {
+                        output[pos] = source[pos];
+                    }
+                    pos++;
+                }
+            }
+
+            if (output != null && pos < sourceLength)
+            {
+                source.Slice(pos).CopyTo(output.AsSpan(pos));
+            }
+
+            return sourceLength;
+        }
+
+        int count = CountOccurrences(source, sourceLength, pattern);
+
+        if (count == 0)
+        {
+            return sourceLength;
+        }
+
+        int newSize = sourceLength - (count * pattern.Length) + (count * replacement.Length);
+        output = new byte[newSize];
+
+        int writePos = 0;
+        int readPos = 0;
+
+        while (readPos < sourceLength)
+        {
+            if (readPos <= sourceLength - pattern.Length &&
+                source.Slice(readPos, pattern.Length).SequenceEqual(pattern))
+            {
+                replacement.CopyTo(output.AsSpan(writePos));
+                writePos += replacement.Length;
+                readPos += pattern.Length;
+            }
+            else
+            {
+                output[writePos++] = source[readPos++];
+            }
+        }
+
+        return newSize;
+    }
+
+    private Tensor EncodeText(string text)
+    {
+        return torch.WrappedTensorDisposeScope(() =>
+        {
+            int maxLen = _config.Data.TextLength;
+            int byteCount = Encoding.UTF8.GetByteCount(text);
+
+            Span<byte> buffer = stackalloc byte[256];
+            byte[]? array = byteCount > 256 ? new byte[byteCount] : null;
+            Span<byte> sourceSpan = array ?? buffer.Slice(0, byteCount);
+
+            Encoding.UTF8.GetBytes(text, sourceSpan);
+
+            ReadOnlySpan<byte> s1Pattern = "[S1]"u8;
+            ReadOnlySpan<byte> s2Pattern = "[S2]"u8;
+            ReadOnlySpan<byte> s1Replacement = stackalloc byte[] { 0x01 };
+            ReadOnlySpan<byte> s2Replacement = stackalloc byte[] { 0x02 };
+
+            int resultLength = ReplaceInPlace(sourceSpan, byteCount, s1Pattern, s1Replacement, out byte[] replaced);
+            resultLength = ReplaceInPlace(replaced ?? sourceSpan, resultLength, s2Pattern, s2Replacement, out byte[] final);
+
+            byte[] resultBytes = final ?? replaced ?? array ?? sourceSpan.ToArray();
+
+            int tokenCount = Math.Min(maxLen, resultLength);
+            long[] tokens = new long[tokenCount];
+
+            for (int i = 0; i < tokenCount; i++)
+            {
+                tokens[i] = resultBytes[i];
+            }
+
+            return tensor(tokens, dtype: ScalarType.Int64, device: Device);
+        });
+    }
+
+    private Tensor PadTextInput(Tensor[] textTokens)
+    {
+        return torch.WrappedTensorDisposeScope(() =>
+        {
+            int textPadValue = _config.Data.TextPadValue;
+            int maxLen = _config.Data.TextLength;
+            int batchSize = textTokens.Length;
+
+            Tensor srcTokens = torch.full(
+                new long[] { batchSize, 1, maxLen },
+                textPadValue,
+                dtype: ScalarType.Int64,
+                device: Device
+            );
+
+            for (int i = 0; i < batchSize; i++)
+            {
+                int currentLen = (int)textTokens[i].shape[0];
+                if (currentLen > 0)
+                {
+                    int copyLen = Math.Min(currentLen, maxLen);
+                    srcTokens[i, 0, ..copyLen] = textTokens[i][..copyLen];
+                }
+            }
+
+            return srcTokens;
+        });
+    }
+
+    #endregion Text Processing Methods
+
+    #region Audio Prompt Processing
+
+    /// <summary>
+    /// Prepares the audio prompts for the model.
+    /// </summary>
+    /// <param name="batchSize">Requested number of prompts, used to set prefill steps. Supports batch size greater than the number of audio prompts.</param>
+    /// <param name="audioPrompts">Optional list of audio prompts as tensors. Can be null or empty.</param>
+    /// <returns>Tuple of (delayed audio batch tensor, array of prefill steps)</returns>
+    private (Tensor, int[]) PrepareAudioPrompt(int batchSize, List<Tensor>? audioPrompts = null)
+    {
+        using var scope = torch.NewDisposeScope();
+
+        int numChannels = _config.Data.Channels;
+        int audioBosValue = _config.Data.AudioBosValue;
+
+        int[] delayPattern = _config.Data.DelayPattern;
+        int maxDelayPattern = delayPattern.Max();
+        int batch;
+        long maxlength;
+
+        if (audioPrompts is null || audioPrompts.Count == 0)
+        {
+            batch = batchSize;
+            maxlength = maxDelayPattern;
+        }
+        else
+        {
+            batch = Math.Max(batchSize, audioPrompts.Count);
+            maxlength = audioPrompts.Select(p => p?.shape[0] ?? 0).Max() + maxDelayPattern;
+        }
+
+        var prefillSteps = new List<int>();
+
+        Tensor prefill = torch.full(
+                size: new long[] { batch, maxlength, numChannels },
+                value: -1,
+                dtype: torch.int32,
+                device: Device);
+
+        prefill[TensorIndex.Colon, 0, TensorIndex.Colon] = audioBosValue;
+
+        if (audioPrompts is null || audioPrompts.Count == 0)
+        {
+            for (int i = 0; i < batch; i++)
+            {
+                prefillSteps.Add(1);
+            }
+        }
+        else
+        {
+            for (int i = 0; i < batch; i++)
+            {
+                var prompt = audioPrompts.ElementAtOrDefault(i);
+                if (prompt is not null)
+                {
+                    prompt = prompt.to(torch.int32, device: Device);
+                    prefill[i, 1..(int)(prompt.shape[0] + 1), TensorIndex.Colon] = prompt;
+                    prefillSteps.Add((int)prompt.shape[0] + 1);
+                }
+                else
+                {
+                    prefillSteps.Add(1);
+                }
+            }
+        }
+
+        (Tensor t_idx_BxTxC, Tensor indices_BTCx3) delayPrecomp = AudioUtils.BuildDelayIndices(
+                B: batch,
+                T: (int)maxlength,
+                C: numChannels,
+                delayPattern: delayPattern);
+
+        var delayedBatch = AudioUtils.ApplyAudioDelay(
+            audio_BxTxC: prefill,
+            padValue: -1,
+            bosValue: audioBosValue,
+            precomp: delayPrecomp);
+
+        return (delayedBatch.MoveToOuterDisposeScope(), prefillSteps.ToArray());
+    }
+
+    #endregion Audio Prompt Processing
+
+    /// <summary>
+    /// Sets the seed value for random number generation to ensure voice consistency across runs.
+    /// </summary>
+    /// <param name="seed">The seed value to use for random number generation. Must be a non-negative integer.</param>
+    public static void SetSeed(int seed)
+    {
+        torch.manual_seed(seed);
+        torch.cuda.manual_seed_all(seed);
+        torch.random.manual_seed(seed);
+    }
+
+    /// <summary>
+    /// Samples the next token from logits.
+    /// </summary>
+    /// <param name="logits">Token logits</param>
+    /// <param name="temperature">Sampling temperature - controls randomness (higher = more random)</param>
+    /// <param name="topP">Top-p (nucleus) sampling probability threshold</param>
+    /// <param name="topK">Top-k filter parameter - limits sampling to top k most likely tokens</param>
+    /// <param name="audioEosValue">End-of-sequence token value for special handling</param>
+    /// <returns>Sampled token indices</returns>
+    public static Tensor SampleNextToken(
+        Tensor logits,
+        float temperature,
+        float topP,
+        int? topK = null,
+        int? audioEosValue = null)
+    {
+        using var scope = torch.NewDisposeScope();
+
+        // Greedy sampling for temperature=0
+        if (temperature < 1e-5f)
+        {
+            return argmax(logits, dim: -1).MoveToOuterDisposeScope();
+        }
+
+        if (audioEosValue is >= 0)
+        {
+            // Mask out EOS token for non-first channels
+            var topLogitIndices_BCxV = argmax(logits, dim: -1);
+            var eosNotHighestMask_BCxV = topLogitIndices_BCxV.ne(audioEosValue);
+            var maskEosUnlessHighest_BCxV = zeros_like(logits, dtype: ScalarType.Bool);
+
+            maskEosUnlessHighest_BCxV[eosNotHighestMask_BCxV, audioEosValue] = true;
+            logits = logits.masked_fill(maskEosUnlessHighest_BCxV, float.NegativeInfinity);
+        }
+
+        // logits: Shape [C, V] -> scaled by temperature
+        logits = logits.div(temperature);
+
+        // Apply top-k filtering if specified
+        if (topK.HasValue)
+        {
+            (_, Tensor indices) = topk(logits, k: topK.Value, dim: -1);
+
+            var mask = ones_like(logits, dtype: ScalarType.Bool);
+            var falseValues = zeros_like(indices, dtype: ScalarType.Bool);
+
+            // Scatter false values at top-k indices
+            mask.scatter_(-1, indices, falseValues);
+
+            // Mask out non-top-k values with -inf
+            logits.masked_fill_(mask, float.NegativeInfinity);
+        }
+
+        if (topP < 1.0f)
+        {
+            // probs: Shape [C, V] - probability distribution
+            var probs = softmax(logits, dim: -1);
+
+            // Sort probabilities in descending order
+            // sortedProbs: Shape [C, V] - sorted probabilities
+            // sortedIndices: Shape [C, V] - original indices
+            var (sortedProbs, sortedIndices) = sort(probs, dim: -1, descending: true);
+
+            // Calculate cumulative probabilities
+            // cumulativeProbs: Shape [C, V] - cumulative sum
+            var cumulativeProbs = cumsum(sortedProbs, dim: -1);
+
+            // Create mask for tokens exceeding top-p threshold
+            var sortedIndicesToRemove = cumulativeProbs.gt(topP);
+            sortedIndicesToRemove = torch.roll(sortedIndicesToRemove, shifts: 1, dims: -1);
+            sortedIndicesToRemove[TensorIndex.Ellipsis, 0] = torch.zeros_like(sortedIndicesToRemove[TensorIndex.Ellipsis, 0]);
+
+            // Scatter mask back to original indices
+            // indicesToRemove: Shape [C, V] - remapped mask
+            var indicesToRemove = zeros_like(sortedIndicesToRemove);
+            indicesToRemove.scatter_(dim: -1, sortedIndices, sortedIndicesToRemove);
+
+            // Mask out tokens beyond top-p cumulative probability
+            logits.masked_fill_(indicesToRemove, float.NegativeInfinity).MoveToOuterDisposeScope();
+        }
+
+        // Calculate final probabilities and sample
+        var finalProbs = softmax(logits, dim: -1);
+        var sampledIndices = multinomial(finalProbs, num_samples: 1);
+        var sampledsqueezed = sampledIndices.squeeze_(1);
+        return sampledsqueezed.MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
+    /// Performs a single step of decoder inference.
+    /// </summary>
+    /// <param name="tokensBx1xC">Current token tensor with shape [Batch*2, 1, Channels]</param>
+    /// <param name="decState">Decoder inference state</param>
+    /// <param name="cfgScale">Classifier-free guidance scale factor</param>
+    /// <param name="temperature">Sampling temperature</param>
+    /// <param name="topP">Top-p (nucleus) sampling threshold</param>
+    /// <param name="topK">Top-k sampling threshold</param>
+    /// <param name="currentIdx">Current decoding step index</param>
+    /// <returns>Next token predictions with shape [Batch, Channels]</returns>
+    public Tensor DecoderStep(
+        Tensor tokensBx1xC,
+        DecoderInferenceState decState,
+        float cfgScale,
+        float temperature,
+        float topP,
+        int topK,
+        int currentIdx)
+    {
+        using var scope = NewDisposeScope();
+
+        var B = tokensBx1xC.shape[0] / 2;
+        var audioEosValue = _config.Data.AudioEosValue;
+
+        // Get logits from decoder
+        var logitsBx1xCxV = _model.Decoder.DecodeStep(tokensBx1xC, decState, currentIdx);
+        var logitsLast2BxCxV = logitsBx1xCxV.index(TensorIndex.Colon, -1);
+        var logitsLastBx2xCxV = logitsLast2BxCxV.view(B, 2, -1, logitsLast2BxCxV.shape[^1]);
+
+        // Split conditional and unconditional paths
+        var uncondLogitsBxCxV = logitsLastBx2xCxV.index(TensorIndex.Colon, 0, TensorIndex.Colon, TensorIndex.Colon);
+        var condLogitsBxCxV = logitsLastBx2xCxV.index(TensorIndex.Colon, 1, TensorIndex.Colon, TensorIndex.Colon);
+
+        // Apply classifier-free guidance
+        var logitsBxCxV = condLogitsBxCxV + (cfgScale * (condLogitsBxCxV - uncondLogitsBxCxV));
+
+        // Fixed indexing bug: mask invalid tokens properly
+        logitsBxCxV.index(TensorIndex.Colon, TensorIndex.Colon, TensorIndex.Slice(audioEosValue + 1))
+            .fill_(float.NegativeInfinity);
+
+        logitsBxCxV.index(TensorIndex.Colon, TensorIndex.Slice(1), TensorIndex.Slice(audioEosValue))
+            .fill_(float.NegativeInfinity);
+
+        // Reduce EOS probability for first channel
+        logitsBxCxV.index(TensorIndex.Colon, 0, audioEosValue).mul_(0.8f);
+
+        // Sample next token
+        var flatLogitsBCxV = logitsBxCxV.view(B * _config.Data.Channels, -1);
+        var predBC = SampleNextToken(
+            flatLogitsBCxV.to(ScalarType.Float32),
+            temperature,
+            topP,
+            topK,
+            audioEosValue);
+
+        var predBxC = predBC.view(B, _config.Data.Channels);
+        return predBxC.MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
+    /// Disposes resources.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Generates audio from a single text dialog prompt.
+    /// </summary>
+    /// <param name="text">Input text prompt</param>
+    /// <param name="maxTokens">Maximum number of audio tokens to generate</param>
+    /// <param name="cfgScale">Scale factor for classifier-free guidance</param>
+    /// <param name="temperature">Sampling temperature</param>
+    /// <param name="topP">Cumulative probability threshold for nucleus sampling</param>
+    /// <param name="cfgFilterTopK">Number of top logits to consider for CFG filtering</param>
+    /// <param name="audioPrompt">Optional audio prompt tensor for conditioning</param>
+    /// <param name="audioPromptPath">Optional path to audio file for prompt</param>
+    /// <param name="verbose">Whether to print progress information</param>
+    /// <returns>The audio waveform as a float array</returns>
+    public float[] Generate(
+        string text,
+        int? maxTokens = null,
+        float cfgScale = 3.0f,
+        float temperature = 1.2f,
+        float topP = 0.95f,
+        int cfgFilterTopK = 45,
+        Tensor? audioPrompt = null,
+        string? audioPromptPath = null,
+        bool? verbose = null)
+    {
+        return Generate([text], maxTokens, cfgScale, temperature, topP, cfgFilterTopK,
+                            audioPrompt is null ? null : [audioPrompt],
+                            audioPromptPath is null ? null : [audioPromptPath],
+                            verbose)[0];
+    }
+
+    /// <summary>
+    /// Generates audio corresponding to the input list of text dialogs.
+    /// </summary>
+    /// <param name="text">List of input text prompts for batch generation</param>
+    /// <param name="maxTokens">Maximum number of audio tokens to generate per prompt</param>
+    /// <param name="cfgScale">Scale factor for classifier-free guidance</param>
+    /// <param name="temperature">Temperature for sampling</param>
+    /// <param name="topP">Cumulative probability threshold for nucleus sampling</param>
+    /// <param name="cfgFilterTopK">Number of top logits to consider for CFG filtering</param>
+    /// <param name="audioPrompt">Optional list of audio prompt tensors for conditioning</param>
+    /// <param name="audioPromptPath">Optional list of paths to audio files for prompts</param>
+    /// <param name="verbose">Whether to print progress information</param>
+    /// <returns>List of generated audio waveforms as float arrays</returns>
+    public List<float[]> Generate(
+        List<string> text,
+        int? maxTokens = null,
+        float cfgScale = 3.0f,
+        float temperature = 1.2f,
+        float topP = 0.95f,
+        int cfgFilterTopK = 45,
+        List<Tensor>? audioPrompt = null,
+        List<string>? audioPromptPath = null,
+        bool? verbose = null)
+    {
+        if (verbose is not null)
+        {
+            _verbose = verbose.Value;
+        }
+        using var inference = torch.inference_mode();
+        using var scope = torch.NewDisposeScope();
+
+        // Note: Need to ensure values put into tensors are either created or cast to int64
+        // because TorchSharp does not implicitly convert types for CUDA tensors.
+
+        // Initialize parameters
+        int batchSize = text.Count;
+        var audioEosValue = _config.Data.AudioEosValue;
+        var audioPadValue = _config.Data.AudioPadValue;
+        var delayPattern = _config.Data.DelayPattern;
+        maxTokens ??= _config.Data.AudioLength;
+        var maxDelayPattern = (long)delayPattern.Max();
+        var delayPatternCx = torch.tensor(delayPattern, dtype: torch.int64, device: Device);
+
+        // Set model to eval mode
+        _model.eval();
+
+        Stopwatch? totalTimer = null;
+        if (_verbose)
+        {
+            totalTimer = Stopwatch.StartNew();
+            Console.WriteLine("generate: starting generation");
+        }
+
+        var prompts = audioPrompt is null ? LoadAudioPrompts(audioPromptPath)
+                    : [.. audioPrompt, .. LoadAudioPrompts(audioPromptPath)];
+
+        // Encode text and capture text lengths for speed factor calculation
+        var encodedTexts = text.Select(t => EncodeText(t)).ToArray();
+        var textLengths = encodedTexts.Select(t => (int)t.shape[0]).ToArray();
+
+        var processedText = PadTextInput(encodedTexts);
+        var (decState, decOutput) = PrepareGeneration(processedText, prompts, maxTokens);
+        int decStep = decOutput.PrefillSteps.Min() - 1;
+
+        int currentIdx = decStep;
+        Tensor eosDetectedBx = torch.zeros(batchSize, dtype: ScalarType.Bool, device: Device);
+        Tensor eosCountdownBx = torch.full(batchSize, value: -1L, dtype: torch.int64, device: Device);
+        Tensor finishedStepBx = torch.full(batchSize, value: -1L, dtype: torch.int64, device: Device);
+
+        var bosOver = false;
+        Stopwatch? stepTimer = null;
+
+        if (_verbose)
+        {
+            Console.WriteLine("generate: starting generation");
+            stepTimer = Stopwatch.StartNew();
+        }
+
+        // Generation Loop
+        while (decStep < maxTokens)
+        {
+            if (eosCountdownBx.eq(0).all().item<bool>())
+            {
+                break;
+            }
+
+            var currentStepIdx = decStep + 1;
+            decState.PrepareStep(decStep);
+
+            // Get current tokens and expand for CFG
+            var tokensBx1xC = decOutput.GetTokensAt(decStep).repeat_interleave(2, dim: 0);
+
+            // Generate next tokens
+            var predBxC = DecoderStep(
+                tokensBx1xC,
+                decState,
+                cfgScale,
+                temperature,
+                topP,
+                cfgFilterTopK,
+                currentIdx);
+
+            currentIdx += 1;
+
+            // Handle EOS detection and propagation
+            using (var activeMaskBx = eosCountdownBx.ne(0))
+            using (var eosTriggerBx = torch.zeros_like(activeMaskBx))
+            {
+                if (activeMaskBx.any().item<bool>())
+                {
+                    var isEosToken = eosDetectedBx[activeMaskBx].logical_not()
+                        .logical_and(predBxC.index(activeMaskBx, 0).eq(audioEosValue));
+                    var isMaxLen = currentStepIdx >= maxTokens - maxDelayPattern;
+                    eosTriggerBx[activeMaskBx] = isEosToken.logical_or(isMaxLen);
+                }
+
+                eosDetectedBx = eosDetectedBx.logical_or(eosTriggerBx);
+                var startCountdownMaskBx = eosTriggerBx.logical_and(eosCountdownBx.lt(0));
+
+                if (startCountdownMaskBx.any().item<bool>())
+                {
+                    eosCountdownBx[startCountdownMaskBx] = maxDelayPattern;
+                    finishedStepBx[startCountdownMaskBx] = (long)currentStepIdx;
+                }
+            }
+
+            // Handle padding after EOS
+            using (var paddingMaskBx = eosCountdownBx.gt(0))
+            {
+                if (paddingMaskBx.any().item<bool>())
+                {
+                    var predActiveBxC = predBxC.index(paddingMaskBx).clone();
+                    var countdownActiveBx = eosCountdownBx.index(paddingMaskBx);
+                    var stepAfterEosBx = maxDelayPattern - countdownActiveBx;
+                    var stepAfterEosBx_ = stepAfterEosBx.unsqueeze(1);
+                    var delayPatternCx_ = delayPatternCx.unsqueeze(0);
+
+                    var eosMaskNxC = stepAfterEosBx_.eq(delayPatternCx_);
+                    var padMaskNxC = stepAfterEosBx_.gt(delayPatternCx_);
+                    predActiveBxC[eosMaskNxC] = (long)audioEosValue;
+                    predActiveBxC[padMaskNxC] = (long)audioPadValue;
+                    predBxC[paddingMaskBx] = predActiveBxC;
+                    eosCountdownBx[paddingMaskBx] -= 1;
+                }
+            }
+
+            // Update BOS state
+            if (!bosOver)
+            {
+                bosOver = decOutput.PrefillSteps.All(prefillStep =>
+                        decStep - prefillStep > maxDelayPattern);
+            }
+
+            decOutput.UpdateOne(predBxC, currentStepIdx, !bosOver);
+            decStep++;
+
+            if (_verbose && decStep % 86 == 0)
+            {
+                stepTimer?.Stop();
+                var duration = stepTimer?.Elapsed.TotalSeconds ?? 1;
+                Console.WriteLine($"duration time {duration:F3}s");
+
+                if (duration > 0)
+                {
+                    double speed = 86 * batchSize / duration;
+                    double realtimeFactor = batchSize / duration;
+                    Console.WriteLine($"generate step {decStep}: speed={speed:F3} tokens/s, realtime factor={realtimeFactor:F3}x");
+                }
+                stepTimer?.Restart();
+            }
+        }
+
+        // Finalize generation
+        var finalStep = decStep + 1;
+        finishedStepBx[finishedStepBx == -1] = finalStep - maxDelayPattern;
+        var prefillStepsTensor = torch.tensor(decOutput.PrefillSteps, device: _device);
+
+        var lengthsBx = finishedStepBx - prefillStepsTensor;
+        torch.clamp_(lengthsBx, min: 0);
+
+        var maxLen = lengthsBx.max().item<long>() + maxDelayPattern;
+        if (maxLen > 0)
+        {
+            int numChannels = _config.Data.Channels;
+            var generatedCodes = torch.full(
+                size: new[] { batchSize, maxLen, numChannels },
+                value: audioPadValue,
+                dtype: torch.int64,
+                device: _device);
+
+            for (int i = 0; i < batchSize; i++)
+            {
+                int startStep = decOutput.PrefillSteps[i];
+                var actualLen = lengthsBx[i].item<long>() + maxDelayPattern;
+                Console.WriteLine($"Length of lengthsBx for batch {i} after decode: {actualLen}");
+                if (actualLen > 0)
+                {
+                    Tensor tokensToCopy = decOutput.GeneratedTokens[i, TensorIndex.Slice(startStep, startStep + actualLen), TensorIndex.Colon];
+                    generatedCodes[i, TensorIndex.Slice(stop: actualLen), TensorIndex.Colon] = tokensToCopy;
+                }
+            }
+
+            if (_verbose && totalTimer is not null)
+            {
+                totalTimer.Stop();
+                var seconds = totalTimer.Elapsed.TotalSeconds;
+                var realTimeSeconds = finalStep / 86.0; // 86 steps = 1 second realtime
+
+                Console.WriteLine($"generate: total duration={seconds:F3}s, total steps={finalStep}");
+                Console.WriteLine($"total generate speed={finalStep / seconds:F3} tokens/s, total realtime factor={batchSize * realTimeSeconds / seconds:F3}x");
+            }
+
+            decState.Dispose();
+            return GenerateOutput(generatedCodes.MoveToOuterDisposeScope(), lengthsBx.MoveToOuterDisposeScope(), textLengths);
+        }
+
+        Console.WriteLine("Warning: Nothing was generated.");
+        return [];
+    }
+
+    /// <summary>
+    /// Loads audio from a file and encodes it using the DAC model.
+    /// </summary>
+    /// <param name="audioPath">Path to the audio file</param>
+    /// <returns>Encoded audio tensor</returns>
+    public Tensor? LoadAudio(string audioPath)
+    {
+        if (!File.Exists(audioPath))
+        {
+            return null;
+        }
+
+        float[] audioData;
+        int sampleRate;
+        int channels;
+
+        using (var reader = new AudioFileReader(audioPath))
+        {
+            sampleRate = reader.WaveFormat.SampleRate;
+            channels = reader.WaveFormat.Channels;
+            var length = (int)reader.Length;
+            var bytesPerSample = reader.WaveFormat.BitsPerSample / 8;
+            var samplesPerChannel = length / (bytesPerSample * channels);
+
+            // Read samples
+            var buffer = new float[samplesPerChannel * channels];
+            reader.Read(buffer, 0, buffer.Length);
+
+            // Convert to mono if needed
+            if (channels > 1)
+            {
+                var monoData = new float[samplesPerChannel];
+                for (int i = 0; i < samplesPerChannel; i++)
+                {
+                    float sum = 0;
+                    for (int c = 0; c < channels; c++)
+                    {
+                        sum += buffer[(i * channels) + c];
+                    }
+                    monoData[i] = sum / channels;
+                }
+                audioData = monoData;
+            }
+            else
+            {
+                audioData = buffer;
+            }
+        }
+        if (sampleRate != _config.SampleRate)
+        {
+            Console.WriteLine($"Warning: Sample rate mismatch ({sampleRate} != {_config.SampleRate})");
+            Core.Utils.AudioUtils.ResampleLinear(audioData, sampleRate, _config.SampleRate);
+        }
+
+        return Encode(tensor(audioData).reshape(1, -1).to(_device));
+    }
+
+    /// <summary>
+    /// Saves audio to a WAV file.
+    /// </summary>
+    /// <param name="path">Output file path</param>
+    /// <param name="audio">Audio data tensor to save</param>
+    public static void SaveAudio(string path, Tensor audio)
+    {
+        using var scope = NewDisposeScope();
+        using var cpuAudio = audio.detach().to(ScalarType.Float32);
+
+        // Get the actual number of audio samples
+        var numSamples = cpuAudio.numel();
+        var audioData = new float[numSamples];
+
+        using var flatAudio = cpuAudio.view(-1);
+        var dataSpan = flatAudio.data<float>();
+        dataSpan.CopyTo(audioData);
+
+        SaveAudio(path, audioData);
+    }
+
+    public static void SaveAudio(string path, float[] audio)
+    {
+        // Normalize the audio
+        var absMax = audio.Select(Math.Abs).Max();
+        if (absMax > 10.0f)
+        {
+            Console.WriteLine($"Warning: Audio values out of expected range. Normalizing from {absMax} to [-1, 1]");
+            for (int i = 0; i < audio.Length; i++)
+            {
+                audio[i] /= absMax;
+            }
+        }
+
+        using var writer = new WaveFileWriter(path, new WaveFormat(DefaultSampleRate, 16, 1));
+
+        // Convert float array to Int16 samples for 16-bit WAV format
+        // NAudio expects integer samples for WaveFileWriter
+        var intSamples = new short[audio.Length];
+        for (int i = 0; i < audio.Length; i++)
+        {
+            // Clamp to [-1, 1] range before conversion
+            var clampedSample = Math.Max(-1.0f, Math.Min(1.0f, audio[i]));
+            intSamples[i] = (short)(clampedSample * 32767);
+        }
+
+        writer.WriteSamples(intSamples, 0, intSamples.Length);
+    }
+
+    /// <summary>
+    /// Disposes resources.
+    /// </summary>
+    /// <param name="disposing">Whether to dispose managed resources</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+            {
+                _model?.Dispose();
+                _dacModel?.Dispose();
+            }
+            _model = null;
+            _dacModel = null;
+            _disposed = true;
+        }
+    }
+
+    private static Tensor AdjustSpeed(Tensor audio, float speedFactor)
+    {
+        if (Math.Abs(speedFactor - 1.0f) < 1e-5f)
+        {
+            return audio.alias();
+        }
+
+        var originalLen = audio.size(-1);
+        var targetLen = (int)(originalLen / speedFactor);
+        if (targetLen <= 0 || targetLen == originalLen)
+        {
+            return audio.alias();
+        }
+        using var scope = NewDisposeScope();
+        var xOriginal = torch.arange(originalLen, device: audio.device);
+        var xResampled = torch.linspace(0, originalLen - 1, targetLen, device: audio.device);
+        // Use linear interpolation for speed adjustment
+        var audioTensorSped = TorchUtils.Interp(xResampled, xOriginal, audio);
+        return audioTensorSped.MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
+    /// Decodes DAC codebook indices to audio waveform
+    /// </summary>
+    /// <param name="audioCodes">Input code tensor [T, C]</param>
+    /// <returns>Audio waveform tensor [1, T]</returns>
+    private Tensor Decode(Tensor audioCodes)
+    {
+        using var scope = torch.NewDisposeScope();
+        // Reshape for DAC: [1, C, T]
+        using var audioValues = _dacModel!.FromCodes(audioCodes.unsqueeze(0).transpose(1, 2));
+
+        // Decode through DAC model, Remove batch dimension
+        return _dacModel.Decode(audioValues).squeeze_().MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
+    /// Encodes audio waveform into DAC codebook indices
+    /// </summary>
+    /// <param name="audio">Input audio tensor [C, T]</param>
+    /// <returns>Encoded frame tensor [T, C]</returns>
+    private Tensor Encode(Tensor audio)
+    {
+        using var scope = torch.NewDisposeScope();
+
+        // Add batch dimension [1, C, T]
+        audio = audio.unsqueeze(0);
+        var (_, encodedFrame, _, _, _) = _dacModel.Encode(audio, sampleRate: _config.SampleRate);
+
+        // Remove batch dim and transpose to [T, C]
+        return encodedFrame
+            .squeeze(0)
+            .transpose(0, 1)
+            .MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
+    /// Converts generated delayed codes into audio waveforms.
+    /// </summary>
+    /// <param name="generatedCodes">Generated audio codes with delays [B, T_gen, C]</param>
+    /// <param name="lengthsBx">Valid length of codes per batch item [B]</param>
+    /// <param name="textLengths">Original text prompt lengths for speed factor calculation [B]</param>
+    /// <returns>List of audio waveforms as numpy arrays</returns>
+    private List<float[]> GenerateOutput(Tensor generatedCodes, Tensor lengthsBx, int[] textLengths)
+    {
+        int numChannels = _config.Data.Channels;
+        int batchSize = (int)generatedCodes.shape[0];
+        int sequenceLength = (int)generatedCodes.shape[1];
+        var delayPattern = _config.Data.DelayPattern;
+        int audioPadValue = _config.Data.AudioPadValue;
+        int maxDelayPattern = delayPattern.Max();
+        Tensor codebook;
+
+        using (var scope = torch.NewDisposeScope())
+        {
+            // Build indices to undo the channel delays
+            var revertPrecomp = AudioUtils.BuildRevertIndices(
+                B: batchSize,
+                T: sequenceLength,
+                C: numChannels,
+                delayPattern: delayPattern
+            );
+
+            // Apply the revert operation to undo delays
+            var unmaskedCodebook = AudioUtils.RevertAudioDelay(
+                audio_BxTxC: generatedCodes,
+                padValue: audioPadValue,
+                precomp: revertPrecomp,
+                T: sequenceLength
+            );
+
+            // Remove the delay pattern padding
+            codebook = unmaskedCodebook[TensorIndex.Colon, TensorIndex.Slice(stop: -maxDelayPattern), TensorIndex.Colon];
+            // Clamp to valid codebook range [0, 1023]
+            var minValidIndex = MinValidCodebookIndex;
+            var maxValidIndex = MaxValidCodebookIndex;
+            var invalidMask = codebook.lt(minValidIndex).logical_or(codebook.gt(maxValidIndex));
+            codebook[invalidMask] = 0L;
+            codebook.MoveToOuterDisposeScope();
+        }
+
+        var audios = new List<float[]>();
+
+        // Speed factor calculation using configuration settings
+        var speedfactor = 1.0f;
+        // Process each item in batch
+        if (_dacModel != null)
+        {
+            for (int i = 0; i < batchSize; i++)
+            {
+                var length = (int)lengthsBx[i].item<long>();
+                var audioTensor = Decode(codebook[i, TensorIndex.Slice(stop: length), TensorIndex.Colon]);
+
+                if (_config.SlowdownMode == AudioSlowdownMode.Dynamic)
+                {
+                    // Use text length instead of audio code length for speed factor calculation
+                    var textLength = textLengths[i];
+
+                    speedfactor = textLength > _config.DynamicSlowdownStartLength ?
+                        1f - (_config.DynamicSlowdownMaxPercent * Math.Min(1f,
+                            (textLength - _config.DynamicSlowdownStartLength) /
+                            (_config.DynamicSlowdownMaxLength - _config.DynamicSlowdownStartLength))) :
+                        1f;
+                }
+                else
+                {
+                    speedfactor = _config.StaticSlowdownFactor;
+                }
+
+                if (AudioCorrectionMethod == AudioSpeedCorrectionMethod.None ||
+                    (_config.SlowdownMode == AudioSlowdownMode.Dynamic && Math.Abs(speedfactor - 1.0f) < 1e-6f))
+                {
+                    // No audio processing needed, just return raw audio
+                    using var cpuTensor = audioTensor.cpu();
+                    using var detachedTensor = cpuTensor.detach();
+                    audios.Add(detachedTensor.data<float>().ToArray());
+                    continue;
+                }
+
+                if (AudioCorrectionMethod is AudioSpeedCorrectionMethod.TorchSharp or
+                    AudioSpeedCorrectionMethod.All)
+                {
+                    var slowedAudio = AdjustSpeed(audioTensor, speedfactor);
+                    using var cpuTensor = slowedAudio.cpu();
+                    using var detachedTensor = cpuTensor.detach();
+                    audios.Add([.. detachedTensor.data<float>()]);
+                }
+
+                if (AudioCorrectionMethod is AudioSpeedCorrectionMethod.Hybrid or
+                    AudioSpeedCorrectionMethod.All)
+                {
+                    try
+                    {
+                        var halfSlowedAudio = AdjustSpeed(audioTensor, (speedfactor + 1) / 2);
+
+                        using var cpuTensor = halfSlowedAudio.cpu();
+                        using var detachedTensor = cpuTensor.detach();
+                        var audioFloats = detachedTensor.data<float>().ToArray();
+                        var waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(DefaultSampleRate, 1);
+                        var sampleProvider = new NAudioUtils.FloatArraySampleProvider(waveFormat, audioFloats);
+
+                        // Apply half resampling for speed adjustment
+                        var targetSampleRate = (int)(DefaultSampleRate * (1 + ((1 - speedfactor) / 2)));
+                        var highQualityResampler = new WdlResamplingSampleProvider(sampleProvider, targetSampleRate);
+
+                        // Read resampled audio
+                        var outputLength = (int)(audioFloats.Length / speedfactor);
+                        var outputBuffer = new float[outputLength];
+                        var samplesRead = highQualityResampler.Read(outputBuffer, 0, outputLength);
+
+                        var processedAudio = new float[samplesRead];
+                        Array.Copy(outputBuffer, processedAudio, samplesRead);
+                        audios.Add(processedAudio);
+                    }
+                    catch (Exception e)
+                    {
+                        if (AudioCorrectionMethod != AudioSpeedCorrectionMethod.All)
+                        {
+                            throw new InvalidOperationException($"Hybrid slow/resample failed: {e.Message}", e);
+                        }
+                        else if (_verbose)
+                        {
+                            Debug.WriteLine($"Hybrid slow/resample failed: {e.Message}");
+                        }
+                    }
+                }
+
+                if (AudioCorrectionMethod is AudioSpeedCorrectionMethod.NAudioResampling or
+                    AudioSpeedCorrectionMethod.All)
+                {
+                    try
+                    {
+                        using var cpuTensor = audioTensor.cpu();
+                        using var detachedTensor = cpuTensor.detach();
+                        var audioFloats = detachedTensor.data<float>().ToArray();
+                        var waveFormat = WaveFormat.CreateIeeeFloatWaveFormat(DefaultSampleRate, 1);
+                        var sampleProvider = new NAudioUtils.FloatArraySampleProvider(waveFormat, audioFloats);
+
+                        // Apply full resampling for speed adjustment
+                        var targetSampleRate = (int)(DefaultSampleRate * (1 + (1 - speedfactor)));
+                        var highQualityResampler = new WdlResamplingSampleProvider(sampleProvider, targetSampleRate);
+
+                        // Read resampled audio
+                        var outputLength = (int)(audioFloats.Length / speedfactor);
+                        var outputBuffer = new float[outputLength];
+                        var samplesRead = highQualityResampler.Read(outputBuffer, 0, outputLength);
+
+                        var processedAudio = new float[samplesRead];
+                        Array.Copy(outputBuffer, processedAudio, samplesRead);
+                        audios.Add(processedAudio);
+                    }
+                    catch (Exception e)
+                    {
+                        if (AudioCorrectionMethod != AudioSpeedCorrectionMethod.All)
+                        {
+                            throw new InvalidOperationException($"NAudio resampling failed: {e.Message}", e);
+                        }
+                        else if (_verbose)
+                        {
+                            Debug.WriteLine($"NAudio resampling failed: {e.Message}");
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            // Return raw codebook indices if DAC is not loaded
+            for (int i = 0; i < batchSize; i++)
+            {
+                var length = (int)lengthsBx[i].item<long>();
+                using var codebookSlice = codebook[i, TensorIndex.Slice(stop: length), TensorIndex.Colon];
+                using var cpuTensor = codebookSlice.cpu();
+                using var detachedTensor = cpuTensor.detach();
+                audios.Add(detachedTensor.to(float32).data<float>().ToArray());
+            }
+        }
+
+        return audios;
+    }
+
+    private List<Tensor> LoadAudioPrompts(List<string>? audioPromptPaths)
+    {
+        if (audioPromptPaths is null || audioPromptPaths.Count == 0)
+        {
+            return [];
+        }
+
+        var processedPrompts = new List<Tensor>();
+        foreach (var path in audioPromptPaths)
+        {
+            if (LoadAudio(path) is Tensor audio)
+            {
+                processedPrompts.Add(audio);
+            }
+        }
+
+        return processedPrompts;
+    }
+
+    /// <summary>
+    /// Initializes the model state for generation.
+    /// </summary>
+    /// <param name="text">Input text tensor</param>
+    /// <param name="audioPrompts">List of audio prompts (optional)</param>
+    /// <param name="maxTokens">Maximum generation length (optional)</param>
+    /// <returns>Tuple of decoder state and output</returns>
+    private (DecoderInferenceState, DecoderOutput) PrepareGeneration(
+        Tensor text,
+        List<Tensor>? audioPrompts,
+        int? maxTokens = null)
+    {
+        var batchSize = (int)text.shape[0];
+
+        // Prepare conditional and unconditional inputs
+        using var encInputUncond = torch.zeros_like(text);
+        using var stackedInputs = torch.stack([encInputUncond, text], dim: 1);
+        using var encInput = stackedInputs.view(2 * batchSize, -1);
+
+        // Initialize encoder state and get output
+        var encState = EncoderInferenceState.New(_config, text);
+        var encoderOut = _model.forward(encInput, encState);
+
+        // Prepare decoder state
+        List<KVCache> decCrossAttnCache = _model.Decoder.PrecomputeCrossAttnCache(
+            encoderOut, encState.Positions, encState.PaddingMask);
+
+        var decState = DecoderInferenceState.New(
+            _config, encState, encoderOut, decCrossAttnCache, _computeDtype, maxTokens);
+
+        // Prepare audio prompt
+        var (prefill, prefillSteps) = PrepareAudioPrompt(batchSize, audioPrompts);
+
+        // Initialize decoder output
+        var decOutput = DecoderOutput.New(batchSize, _config, Device);
+        decOutput.Prefill(prefill, prefillSteps);
+
+        // Handle prefill steps if needed
+        var decStep = prefillSteps.Min() - 1;
+        if (decStep > 0)
+        {
+            decState.PrepareStep(0, decStep);
+            using var tokens = decOutput.GetTokensAt(0, decStep);
+            using var expandedTokens = tokens.repeat_interleave(2, dim: 0);
+            _model.Decoder.forward(expandedTokens, decState);
+        }
+
+        return (decState.MoveToOuterDisposeScope(), decOutput.MoveToOuterDisposeScope());
+    }
+}

--- a/NeuralCodecs.Torch/Modules/DAC/Decoder.cs
+++ b/NeuralCodecs.Torch/Modules/DAC/Decoder.cs
@@ -8,10 +8,9 @@ namespace NeuralCodecs.Torch.Modules.DAC;
 /// Decoder module that transforms encoded latent representations back into audio waveforms
 /// through a series of upsampling and residual blocks.
 /// </summary>
-public class Decoder : Module<Tensor, Tensor>, IDisposable
+public class Decoder : Module<Tensor, Tensor>
 {
     private readonly Sequential model;
-    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the Decoder class.
@@ -58,17 +57,12 @@ public class Decoder : Module<Tensor, Tensor>, IDisposable
     /// <returns>Decoded audio waveform tensor</returns>
     public override Tensor forward(Tensor x) => model.forward(x);
 
-    /// <summary>
-    /// Disposes the decoder and its resources.
-    /// </summary>
-    public new void Dispose()
+    protected override void Dispose(bool disposing)
     {
-        if (!_disposed)
+        if (disposing)
         {
             model?.Dispose();
-            base.Dispose();
-            _disposed = true;
         }
-        GC.SuppressFinalize(this);
+        base.Dispose(disposing);
     }
 }

--- a/NeuralCodecs.Torch/Modules/DAC/DecoderBlock.cs
+++ b/NeuralCodecs.Torch/Modules/DAC/DecoderBlock.cs
@@ -1,4 +1,3 @@
-using NeuralCodecs.Torch.Modules;
 using TorchSharp.Modules;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
@@ -8,10 +7,9 @@ namespace NeuralCodecs.Torch.Modules.DAC;
 /// <summary>
 /// Represents a decoder block in the DAC (Dilated Audio Codec) architecture.
 /// </summary>
-public class DecoderBlock : Module<Tensor, Tensor>, IDisposable
+public class DecoderBlock : Module<Tensor, Tensor>
 {
     private readonly Sequential block;
-    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the DecoderBlock class.
@@ -49,23 +47,12 @@ public class DecoderBlock : Module<Tensor, Tensor>, IDisposable
     /// Disposes the resources used by this decoder block.
     /// </summary>
     /// <param name="disposing">True to dispose managed resources.</param>
-    protected virtual void Dispose(bool disposing)
+    protected override void Dispose(bool disposing)
     {
-        if (!_disposed)
+        if (disposing)
         {
-            if (disposing)
-            {
-                block.Dispose();
-            }
-            _disposed = true;
+            block.Dispose();
         }
-    }
-
-    
-    /// <inheritdoc/>
-    public void Dispose()
-    {
-        Dispose(disposing: true);
-        GC.SuppressFinalize(this);
+        base.Dispose(disposing);
     }
 }

--- a/NeuralCodecs.Torch/Modules/DAC/Encoder.cs
+++ b/NeuralCodecs.Torch/Modules/DAC/Encoder.cs
@@ -12,8 +12,6 @@ public class Encoder : Module<Tensor, Tensor>, IDisposable
     private readonly int _encoderDim;
     private readonly Sequential block;
 
-    private bool _disposed;
-
     /// <summary>
     /// Initializes a new instance of the Encoder class.
     /// </summary>
@@ -59,22 +57,12 @@ public class Encoder : Module<Tensor, Tensor>, IDisposable
     /// <returns>Encoded representation of the input</returns>
     public override Tensor forward(Tensor x) => block.forward(x);
 
-    public new void Dispose()
-    {
-        Dispose(true);
-        GC.SuppressFinalize(this);
-    }
-
     protected override void Dispose(bool disposing)
     {
-        if (!_disposed)
+        if (disposing)
         {
-            if (disposing)
-            {
-                block?.Dispose();
-            }
-            base.Dispose(disposing);
-            _disposed = true;
+            block?.Dispose();
         }
+        base.Dispose(disposing);
     }
 }

--- a/NeuralCodecs.Torch/Modules/DAC/EncoderBlock.cs
+++ b/NeuralCodecs.Torch/Modules/DAC/EncoderBlock.cs
@@ -45,9 +45,13 @@ public class EncoderBlock : Module<Tensor, Tensor>, IDisposable
     /// <summary>
     /// Disposes the resources used by the encoder block.
     /// </summary>
-    public void Dispose()
+    /// <param name="disposing">True to dispose managed resources.</param>
+    protected override void Dispose(bool disposing)
     {
-        block?.Dispose();
-        GC.SuppressFinalize(this);
+        if (disposing)
+        {
+            block?.Dispose();
+        }
+        base.Dispose(disposing);
     }
 }

--- a/NeuralCodecs.Torch/Modules/DAC/GANLoss.cs
+++ b/NeuralCodecs.Torch/Modules/DAC/GANLoss.cs
@@ -86,10 +86,11 @@ public class GANLoss : AudioLossBase
     /// </summary>
     public override Tensor forward(Tensor fake, Tensor real)
     {
+        using var scope = NewDisposeScope();
         var (fakeAudio, _) = GetAudioTensor(fake);
         var (realAudio, _) = GetAudioTensor(real);
-        var (fakePreds, realPreds) = GetDiscriminatorOutputs(fakeAudio, realAudio);
-        return fakePreds[^1];  // Return final discriminator output
+        var (fakePreds, _) = GetDiscriminatorOutputs(fakeAudio, realAudio);
+        return fakePreds[^1].MoveToOuterDisposeScope();  // Return final discriminator output
     }
 
     protected override void Dispose(bool disposing)

--- a/NeuralCodecs.Torch/Modules/DAC/L1Loss.cs
+++ b/NeuralCodecs.Torch/Modules/DAC/L1Loss.cs
@@ -1,3 +1,4 @@
+using TorchSharp;
 using static TorchSharp.torch;
 
 namespace NeuralCodecs.Torch.Modules.DAC;
@@ -24,6 +25,8 @@ public class L1Loss : AudioLossBase
 
     public override Tensor forward(Tensor x, Tensor y)
     {
-        return _l1Loss.forward(x, y) * _weight;
+        using var scope = torch.NewDisposeScope();
+        var loss = _l1Loss.forward(x, y);
+        return loss.mul_(_weight).MoveToOuterDisposeScope();
     }
 }

--- a/NeuralCodecs.Torch/Modules/DAC/MelSpectrogramLoss.cs
+++ b/NeuralCodecs.Torch/Modules/DAC/MelSpectrogramLoss.cs
@@ -1,5 +1,5 @@
 using NeuralCodecs.Torch.AudioTools;
-using NeuralCodecs.Torch.Utils;
+using TorchSharp;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 
@@ -115,6 +115,7 @@ public class MelSpectrogramLoss : AudioLossBase
 
     public override Tensor forward(Tensor x, Tensor y)
     {
+        using var scope = torch.NewDisposeScope();
         var loss = zeros(1, device: x.device);
 
         for (int i = 0; i < _stftParams.Length; i++)
@@ -132,7 +133,7 @@ public class MelSpectrogramLoss : AudioLossBase
             loss += _magWeight * _lossFn.forward(xMels, yMels);
         }
 
-        return loss * _weight;
+        return loss.mul_(_weight).MoveToOuterDisposeScope();
     }
 
     protected override void Dispose(bool disposing)

--- a/NeuralCodecs.Torch/Modules/DAC/ResidualUnit.cs
+++ b/NeuralCodecs.Torch/Modules/DAC/ResidualUnit.cs
@@ -16,8 +16,6 @@ public class ResidualUnit : Module<Tensor, Tensor>
     /// </summary>
     private readonly Sequential block;
 
-    private bool _disposed;
-
     /// <summary>
     /// Initializes a new instance of the ResidualUnit class
     /// </summary>
@@ -51,26 +49,21 @@ public class ResidualUnit : Module<Tensor, Tensor>
     /// </remarks>
     public override Tensor forward(Tensor x)
     {
-        using var scope = torch.NewDisposeScope();
         var y = block.forward(x);
         var pad = (int)(x.shape[^1] - y.shape[^1]) / 2;
         if (pad > 0)
         {
             x = x[.., .., pad..^pad];
         }
-        return x.add(y).MoveToOuterDisposeScope();
+        return y.add_(x);
     }
 
     protected override void Dispose(bool disposing)
     {
-        if (!_disposed)
+        if (disposing)
         {
-            if (disposing)
-            {
-                block?.Dispose();
-            }
-            base.Dispose(disposing);
-            _disposed = true;
+            block?.Dispose();
         }
+        base.Dispose(disposing);
     }
 }

--- a/NeuralCodecs.Torch/Modules/DAC/SISDRLoss.cs
+++ b/NeuralCodecs.Torch/Modules/DAC/SISDRLoss.cs
@@ -1,4 +1,3 @@
-using TorchSharp;
 using static TorchSharp.torch;
 
 namespace NeuralCodecs.Torch.Modules.DAC;
@@ -53,14 +52,12 @@ public class SISDRLoss : AudioLossBase
         }
         else if (x.dim() == 2)
         {
-            if (x.size(0) == 1 || x.size(0) == 2)
+            if (x.size(0) is 1 or 2)
             {
-                // Likely (channels, time)
                 return x.unsqueeze(0);
             }
             else
             {
-                // Likely (batch, time)
                 return x.unsqueeze(1);
             }
         }
@@ -120,8 +117,8 @@ public class SISDRLoss : AudioLossBase
         {
             var referenceMean = references.mean([1], keepdim: true);
             var estimateMean = estimates.mean([1], keepdim: true);
-            references = references - referenceMean;
-            estimates = estimates - estimateMean;
+            references -= referenceMean;
+            estimates -= estimateMean;
         }
 
         // Compute scaling factor if requested
@@ -141,7 +138,7 @@ public class SISDRLoss : AudioLossBase
         var errorPower = (errorSignal * errorSignal).sum(1);
 
         // Compute loss in dB
-        var loss = -10 * log10(targetPower / (errorPower + EPS) + EPS);
+        var loss = -10 * log10((targetPower / (errorPower + EPS)) + EPS);
 
         // Apply clipping if requested
         if (_clipMin.HasValue)
@@ -164,17 +161,5 @@ public class SISDRLoss : AudioLossBase
         // else "none" - return as is
 
         return loss * _weight;
-    }
-
-    /// <summary>
-    /// Disposes of unmanaged resources
-    /// </summary>
-    protected override void Dispose(bool disposing)
-    {
-        if (disposing)
-        {
-            // No tensors to dispose since we don't keep any persistent state
-        }
-        base.Dispose(disposing);
     }
 }

--- a/NeuralCodecs.Torch/Modules/DAC/Snake1d.cs
+++ b/NeuralCodecs.Torch/Modules/DAC/Snake1d.cs
@@ -49,22 +49,11 @@ public class Snake1d : Module<Tensor, Tensor>
     public override Tensor forward(Tensor x)
     {
         using var scope = NewDisposeScope();
-
-        // Calculate alpha * x
-        using var alphaTensor = alpha * x;
-        // Calculate sin(alpha * x)
-        using var sinVal = sin(alphaTensor);
-        // Calculate sin²(alpha * x)
-        using var sinSquared = sinVal.pow(2);
-
-        // Apply the snake formula: x + sin²(alpha * x) / alpha
-        var output = torch.where(alpha == 0, x, addcdiv(x, sinSquared, alpha, 1));
-
+        var output = torch.where(alpha == 0, x, addcdiv(x, sin(alpha * x).pow_(2), alpha, 1));
         if (cuda_is_available())
         {
             cuda.synchronize();
         }
-
         return output.MoveToOuterDisposeScope();
     }
 

--- a/NeuralCodecs.Torch/Modules/DAC/WNConv1d.cs
+++ b/NeuralCodecs.Torch/Modules/DAC/WNConv1d.cs
@@ -43,6 +43,7 @@ public class WNConv1d : Module<Tensor, Tensor>
     /// <param name="dilation">Spacing between kernel elements. Default is 1.</param>
     /// <param name="groups">Number of blocked connections from input channels to output channels. Default is 1.</param>
     /// <param name="useBias">If true, adds a learnable bias to the output. Default is true.</param>
+    /// <param name="device"></param>
     public WNConv1d(long inChannels, long outChannels, long kernelSize,
         long stride = 1, long padding = 0, long dilation = 1, long groups = 1, bool useBias = true, Device device = null)
         : base($"WNConv1d_{inChannels}_{outChannels}")
@@ -144,6 +145,7 @@ public class WNConv1d : Module<Tensor, Tensor>
         var weightSquared = weight_v.contiguous().pow(2);
         var v_norm = weightSquared.sum([1, 2], keepdim: true, ScalarType.Float32).sqrt();
 
+        // Divide weight_v by its norm and multiply by weight_g
         var normalized = weight_v.div(v_norm.add(1e-7f));
         weight = mul(normalized, weight_g).contiguous();
 

--- a/NeuralCodecs.Torch/Modules/DAC/WNConv2d.cs
+++ b/NeuralCodecs.Torch/Modules/DAC/WNConv2d.cs
@@ -38,8 +38,16 @@ public class WNConv2d : Module<Tensor, Tensor>
         bool useBias = true,
         Device device = null) : base($"WNConv2d_{inChannels}_{outChannels}")
     {
-        if (stride == default) stride = (1, 1);
-        if (padding == default) padding = (0, 0);
+        if (stride == default)
+        {
+            stride = (1, 1);
+        }
+
+        if (padding == default)
+        {
+            padding = (0, 0);
+        }
+
         device ??= torch.CPU;
 
         _stride = stride;

--- a/NeuralCodecs.Torch/Modules/Dia/AttentionMaskUtils.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/AttentionMaskUtils.cs
@@ -1,0 +1,46 @@
+using static TorchSharp.torch;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Creates attention masks for self and cross attention.
+/// </summary>
+public static class AttentionMaskUtils
+{
+    /// <summary>
+    /// Creates the attention mask (self or cross) mimicking JAX segment ID logic.
+    /// </summary>
+    /// <param name="qPaddingMask1d">Query padding mask (shape: [B, Tq])</param>
+    /// <param name="kPaddingMask1d">Key padding mask (shape: [B, Tk])</param>
+    /// <param name="device">Device to create the mask on</param>
+    /// <param name="isCausal">Whether to apply causal masking</param>
+    /// <returns>Attention mask (shape: [B, 1, Tq, Tk])</returns>
+    public static Tensor CreateAttentionMask(
+        Tensor qPaddingMask1d,
+        Tensor kPaddingMask1d,
+        Device device,
+        bool isCausal = false)
+    {
+        using var scope = NewDisposeScope();
+
+        // Reshape masks for broadcasting
+        var pMaskQ = qPaddingMask1d.unsqueeze(2);
+        var pMaskK = kPaddingMask1d.unsqueeze(1);
+
+        var nonPadAttendsNonPad = pMaskQ.logical_and(pMaskK);
+        var padAttendsPad = pMaskQ.logical_not().logical_and(pMaskK.logical_not());
+
+        var mask = nonPadAttendsNonPad.logical_or(padAttendsPad);
+
+        if (isCausal)
+        {
+            var causalMask3d = tril(ones_like(mask[0], dtype: ScalarType.Bool, device: device));
+            var causalMask = mask.logical_and(causalMask3d);
+            return causalMask.unsqueeze(1).MoveToOuterDisposeScope();
+        }
+        else
+        {
+            return mask.unsqueeze(1).MoveToOuterDisposeScope();
+        }
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/AudioUtils.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/AudioUtils.cs
@@ -1,0 +1,209 @@
+using static TorchSharp.torch;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Utility methods for audio processing in the Dia model.
+/// </summary>
+public static class AudioUtils
+{
+    /// <summary>
+    /// Precompute (t_idx_BxTxC, indices_BTCx3) so that out[t, c] = in[t - delay[c], c].
+    /// Negative t_idx => BOS; t_idx >= T => PAD.
+    /// </summary>
+    /// <param name="B">Batch size</param>
+    /// <param name="T">Sequence length</param>
+    /// <param name="C">Number of channels</param>
+    /// <param name="delayPattern">Delay pattern array</param>
+    /// <returns>Tuple containing t_idx_BxTxC and indices_BTCx3</returns>
+    public static (Tensor t_idx_BxTxC, Tensor indices_BTCx3) BuildDelayIndices(int B, int T, int C, int[] delayPattern)
+    {
+        using var scope = NewDisposeScope();
+        var delay_arr = tensor(delayPattern, dtype: int32);
+
+        var t_idx_BxT = broadcast_to(
+            arange(T, dtype: int32)[TensorIndex.None, TensorIndex.Colon],
+            B, T
+        );
+        var t_idx_BxTx1 = t_idx_BxT[TensorIndex.Ellipsis, TensorIndex.None];
+        var t_idx_BxTxC = t_idx_BxTx1 - delay_arr.view(1, 1, C);
+
+        var b_idx_BxTxC = broadcast_to(
+             arange(B, dtype: int32).view(B, 1, 1),
+             B, T, C
+         );
+        var c_idx_BxTxC = broadcast_to(
+            arange(C, dtype: int32).view(1, 1, C),
+            B, T, C
+        );
+
+        // Clamp time indices to [0..T-1]
+        var t_clamped_BxTxC = clamp(t_idx_BxTxC, 0, T - 1);
+
+        var indices_BTCx3 = stack(
+            [
+                b_idx_BxTxC.reshape(-1),
+                t_clamped_BxTxC.reshape(-1),
+                c_idx_BxTxC.reshape(-1),
+            ],
+            dim: 1
+        ).to(int64);  // Ensure indices are long type for indexing
+
+        return (t_idx_BxTxC.MoveToOuterDisposeScope(), indices_BTCx3.MoveToOuterDisposeScope());
+    }
+
+    /// <summary>
+    /// Applies the delay pattern to batched audio tokens using precomputed indices,
+    /// inserting BOS where t_idx LT 0 and PAD where t_idx GTE T.
+    /// </summary>
+    /// <param name="audio_BxTxC">Audio tokens with shape B, T, C</param>
+    /// <param name="padValue">The padding token</param>
+    /// <param name="bosValue">The BOS token</param>
+    /// <param name="precomp">Precomputed indices from BuildDelayIndices</param>
+    /// <returns>Delayed audio tokens with shape B, T, C</returns>
+    public static Tensor ApplyAudioDelay(Tensor audio_BxTxC, int padValue, int bosValue,
+            (Tensor t_idx_BxTxC, Tensor indices_BTCx3) precomp)
+    {
+        using var scope = NewDisposeScope();
+        var device = audio_BxTxC.device;
+        var (t_idx_BxTxC, indices_BTCx3) = precomp;
+
+        var t_idx_device = t_idx_BxTxC.to(device);
+        var indices_device = indices_BTCx3.to(device);
+
+        // Gather using flat indices
+        var gathered_flat = audio_BxTxC[indices_device[TensorIndex.Colon, 0],
+                                            indices_device[TensorIndex.Colon, 1],
+                                            indices_device[TensorIndex.Colon, 2]];
+
+        // Reshape to original tensor shape
+        var gathered_BxTxC = gathered_flat.view(audio_BxTxC.shape);
+
+        // Create masks
+        var mask_bos = t_idx_device < 0;
+        var mask_pad = t_idx_device >= audio_BxTxC.shape[1];
+
+        // Create scalar tensors
+        var bos_tensor = tensor(bosValue, dtype: audio_BxTxC.dtype, device: device);
+        var pad_tensor = tensor(padValue, dtype: audio_BxTxC.dtype, device: device);
+
+        var result_intermediate = where(mask_bos, bos_tensor, gathered_BxTxC);
+        var result_BxTxC = where(mask_pad, pad_tensor, result_intermediate);
+
+        return result_BxTxC.MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
+    /// Precompute indices for the revert operation.
+    /// </summary>
+    /// <param name="B">Batch size</param>
+    /// <param name="T">Sequence length</param>
+    /// <param name="C">Number of channels</param>
+    /// <param name="delayPattern">Delay pattern array</param>
+    /// <returns>
+    /// Tuple containing:
+    /// - t_idx_BxTxC: Time indices plus delay, shape B, T, C
+    /// - indices_BTCx3: Flattened indices for gathering, shape [B*T*C, 3]
+    /// </returns>
+    public static (Tensor t_idx_BxTxC, Tensor indices_BTCx3) BuildRevertIndices(int B, int T, int C, int[] delayPattern)
+    {
+        // delayArr: Shape [C] - holds delay pattern values
+        var delayArr = tensor(delayPattern, int32);
+
+        // Create time indices [B, T, 1] - fixing dtype to match Python
+        // t_idx_BT1: Shape [B, T, 1] - holds indices 0...T-1 for each batch
+        var t_idx_BT1 = broadcast_to(arange(T).unsqueeze(0), B, T);
+        t_idx_BT1 = t_idx_BT1.unsqueeze(-1);
+
+        // Apply delay pattern for each channel B, T, C
+        // For revert, we add the delay rather than subtract it
+        // t_idx_BxTxC: Shape B, T, C - holds t + delay[c] for each position
+        var t_idx_BxTxC = minimum(
+            t_idx_BT1 + delayArr.view(1, 1, C),  // Add delay pattern
+            tensor(T - 1)                       // Clamp to max time index
+        );
+
+        var b_idx_BxTxC = broadcast_to(arange(B).view(B, 1, 1), B, T, C);
+        var c_idx_BxTxC = broadcast_to(arange(C).view(1, 1, C), B, T, C);
+
+        // Stack indices for gather operation [B*T*C, 3]
+        // indices_BTCx3: Shape [B*T*C, 3] - each row is [batch_idx, time_idx, channel_idx]
+        var indices_BTCx3 = stack(new[] {
+            b_idx_BxTxC.reshape(-1),
+            t_idx_BxTxC.reshape(-1),
+            c_idx_BxTxC.reshape(-1)
+        }, dim: 1).to(int64);  // Cast to Int64 for indexing
+
+        return (t_idx_BxTxC, indices_BTCx3);
+    }
+
+    /// <summary>
+    /// Reverts a delay pattern from batched audio tokens using precomputed indices.
+    /// </summary>
+    /// <param name="audio_BxTxC">Input delayed audio tensor, shape B, T, C</param>
+    /// <param name="padValue">Padding value for out-of-bounds indices</param>
+    /// <param name="precomp">Precomputed revert indices tuple</param>
+    /// <param name="T">Original sequence length before padding</param>
+    /// <returns>Reverted audio tensor with same shape as input B, T, C</returns>
+    public static Tensor RevertAudioDelay(Tensor audio_BxTxC, int padValue,
+        (Tensor t_idx_BxTxC, Tensor indices_BTCx3) precomp, int T)
+    {
+        using var scope = NewDisposeScope();
+        var (t_idx_BxTxC, indices_BTCx3) = precomp;
+        var device = audio_BxTxC.device;
+
+        // Move precomputed indices to the same device as audio_BxTxC
+        var t_idx_device = t_idx_BxTxC.to(device);
+        var indices_device = indices_BTCx3.to(device);
+
+        // Gather values
+        var gathered_flat = audio_BxTxC.index(
+           indices_device.index(TensorIndex.Colon, 0),
+           indices_device.index(TensorIndex.Colon, 1),
+           indices_device.index(TensorIndex.Colon, 2));
+
+        // Reshape back to original dimensions
+        var gathered_BxTxC = gathered_flat.view(audio_BxTxC.size());
+
+        // Create pad_tensor on the correct device
+        var pad_tensor = tensor(padValue, dtype: audio_BxTxC.dtype, device: device);
+        var T_val = tensor(T, device: device);
+
+        // Apply mask
+        var result_BxTxC = where(t_idx_device.ge(T_val), pad_tensor, gathered_BxTxC);
+
+        return result_BxTxC.MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
+    /// Decodes audio codes into a tensor representation of audio data using the specified model.
+    /// </summary>
+    /// <remarks>This method uses the provided <see cref="DAC"/> model to first convert the audio
+    /// codes into a quantized representation and then decode the quantized data into audio. Ensure that the input
+    /// tensor contains exactly one frame to avoid an <see cref="ArgumentException"/>.</remarks>
+    /// <param name="model">The <see cref="DAC"/> model used to decode the audio codes.</param>
+    /// <param name="audioCodes">A tensor containing the audio codes to decode. Must contain exactly one frame (i.e., <c>audioCodes.size(0)
+    /// == 1</c>).</param>
+    /// <returns>A <see cref="Tensor"/> representing the decoded audio data.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="audioCodes"/> does not contain exactly one frame.</exception>
+    public static Tensor Decode(Torch.Models.DAC model, Tensor audioCodes)
+    {
+        if (audioCodes.size(0) != 1)
+        {
+            throw new ArgumentException($"Expected one frame, got {audioCodes.size(0)}");
+        }
+
+        try
+        {
+            var quantized = model.FromCodes(audioCodes);
+            var decodedAudio = model.Decode(quantized);
+
+            return decodedAudio;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"Error in decode method: {e.Message}");
+            throw;
+        }
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/CrossAttention.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/CrossAttention.cs
@@ -1,0 +1,202 @@
+using NeuralCodecs.Torch.Config.Dia;
+using NeuralCodecs.Torch.Utils;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Cross-attention module for decoder layers.
+/// </summary>
+public class CrossAttention : Module<Tensor, Tensor, Tensor, Tensor?, Tensor>
+{
+    private readonly int _numQueryHeads;
+    private readonly int _numKvHeads;
+    private readonly int _headDim;
+    private readonly int _outputDim;
+    private readonly int _projectedQueryDim;
+    private readonly int _numGqaGroups;
+    private readonly ScalarType _computeDtype;
+
+    /// <summary>
+    /// Query projection layer.
+    /// </summary>
+    public readonly DenseGeneral q_proj;
+
+    /// <summary>
+    /// Key projection layer.
+    /// </summary>
+    public readonly DenseGeneral k_proj;
+
+    /// <summary>
+    /// Value projection layer.
+    /// </summary>
+    public readonly DenseGeneral v_proj;
+
+    /// <summary>
+    /// Output projection layer.
+    /// </summary>
+    public readonly DenseGeneral o_proj;
+
+    /// <summary>
+    /// Rotary positional embedding layer.
+    /// </summary>
+    public readonly RotaryEmbedding _rotaryEmb;
+
+    /// <summary>
+    /// Creates a new CrossAttention module.
+    /// </summary>
+    /// <param name="config">Model configuration</param>
+    /// <param name="qEmbedDim">Query embedding dimension</param>
+    /// <param name="kvEmbedDim">Key/value embedding dimension</param>
+    /// <param name="numQueryHeads">Number of query heads</param>
+    /// <param name="numKvHeads">Number of key/value heads</param>
+    /// <param name="headDim">Dimension per head</param>
+    /// <param name="computeDtype">Computation data type</param>
+    /// <param name="outEmbedDim">Output embedding dimension (if different from query)</param>
+    public CrossAttention(
+        DiaConfig config,
+        int qEmbedDim,
+        int kvEmbedDim,
+        int numQueryHeads,
+        int numKvHeads,
+        int headDim,
+        ScalarType computeDtype,
+        int? outEmbedDim = null)
+        : base(nameof(CrossAttention))
+    {
+        _numQueryHeads = numQueryHeads;
+        _numKvHeads = numKvHeads;
+        _headDim = headDim;
+        _outputDim = outEmbedDim ?? qEmbedDim;
+        _projectedQueryDim = numQueryHeads * headDim;
+        _computeDtype = computeDtype;
+
+        if (numQueryHeads % numKvHeads != 0)
+        {
+            throw new ArgumentException(
+                $"num_query_heads ({numQueryHeads}) must be divisible by num_kv_heads ({numKvHeads})");
+        }
+
+        _numGqaGroups = numQueryHeads / numKvHeads;
+
+        // Projection layers
+        q_proj = new DenseGeneral(
+            inShapes: new[] { qEmbedDim },
+            outFeatures: new[] { numQueryHeads, headDim },
+            axis: new[] { -1 },
+            weightDtype: computeDtype
+        );
+
+        k_proj = new DenseGeneral(
+            inShapes: new[] { kvEmbedDim },
+            outFeatures: new[] { numKvHeads, headDim },
+            axis: new[] { -1 },
+            weightDtype: computeDtype
+        );
+
+        v_proj = new DenseGeneral(
+            inShapes: new[] { kvEmbedDim },
+            outFeatures: new[] { numKvHeads, headDim },
+            axis: new[] { -1 },
+            weightDtype: computeDtype
+        );
+
+        o_proj = new DenseGeneral(
+            inShapes: new[] { numQueryHeads, headDim },
+            outFeatures: new[] { _outputDim },
+            axis: new[] { -2, -1 },
+            weightDtype: computeDtype
+        );
+
+        RegisterComponents();
+
+        // Create Rotary embeddings
+        _rotaryEmb = new RotaryEmbedding(
+            embeddingDims: headDim,
+            minTimescale: config.Model.RopeMinTimescale,
+            maxTimescale: config.Model.RopeMaxTimescale,
+            computeDtype: computeDtype
+        );
+    }
+
+    /// <summary>
+    /// Forward pass for cross-attention.
+    /// </summary>
+    /// <param name="Xq">Query tensor [B, T, D]</param>
+    /// <param name="qPositions">Query positions [B, T]</param>
+    /// <param name="kvPositions">Key/value positions [B, S]</param>
+    /// <param name="attnMask">Attention mask (optional)</param>
+    /// <returns>Cross-attention output</returns>
+    public override Tensor forward(Tensor Xq, Tensor qPositions, Tensor kvPositions, Tensor? attnMask)
+        => forward(Xq, qPositions, kvPositions, attnMask, null);
+
+    /// <summary>
+    /// Performs cross-attention computation.
+    /// </summary>
+    /// <param name="Xq">Query tensor [B, T, D]</param>
+    /// <param name="qPositions">Query positions [B, T]</param>
+    /// <param name="kvPositions">Key/value positions [B, S]</param>
+    /// <param name="attnMask">Attention mask (optional)</param>
+    /// <param name="cache">KV cache containing precomputed keys and values</param>
+    /// <param name="isCausal">Whether to apply causal masking.</param>
+    /// <returns>Cross-attention output tensor</returns>
+    public Tensor forward(
+        Tensor Xq,
+        Tensor qPositions,
+        Tensor kvPositions,
+        Tensor? attnMask = null,
+        KVCache? cache = null,
+        bool isCausal = false)
+    {
+        using var scope = NewDisposeScope();
+
+        if (cache == null)
+        {
+            throw new ArgumentException(
+                "Cache must be provided for cross-attention. Use PrecomputeCrossAttnCache() to create it.");
+        }
+
+        kvPositions ??= qPositions; // keeping for parity with python
+        var originalDtype = Xq.dtype;
+
+        // Project queries and apply RoPE
+        var XqCompute = Xq.to(_computeDtype);
+        var XqBxTxNxH = q_proj.forward(XqCompute);
+        var XqBxNxTxH = _rotaryEmb.forward(XqBxTxNxH, position: qPositions).transpose(1, 2);
+
+        // Get keys and values from cache
+        var attnK = cache.K;
+        var attnV = cache.V;
+
+        Tensor attnOutput = AttentionUtils.ScaledDotProductAttention(
+            XqBxNxTxH,
+            attnK,
+            attnV,
+            attentionMask: isCausal ? null : attnMask,
+            scale: 1.0f,
+            isCausal: isCausal,
+            enableGqa: _numGqaGroups > 1,
+            gqaGroups: _numGqaGroups
+        );
+        var attnOutputTransposed = attnOutput.transpose(1, 2).contiguous();
+        var output = o_proj.forward(attnOutputTransposed);
+
+        return output.to(originalDtype).MoveToOuterDisposeScope();
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            q_proj?.Dispose();
+            k_proj?.Dispose();
+            v_proj?.Dispose();
+            o_proj?.Dispose();
+            _rotaryEmb?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/Decoder.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/Decoder.cs
@@ -1,0 +1,206 @@
+using NeuralCodecs.Torch.Config.Dia;
+using TorchSharp.Modules;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Transformer Decoder Stack.
+/// </summary>
+public class Decoder : Module<Tensor, DecoderInferenceState, Tensor>
+{
+    private readonly int _numChannels;
+    private readonly int _numLayers;
+    private readonly ModuleList<Embedding> embeddings;
+    private readonly ModuleList<DecoderLayer> layers;
+    private readonly RMSNorm norm;
+    private readonly DenseGeneral logits_dense;
+    private readonly ScalarType _computeDtype;
+
+    /// <summary>
+    /// Creates a new Decoder.
+    /// </summary>
+    /// <param name="config">Model configuration</param>
+    /// <param name="computeDtype">Computation data type</param>
+    public Decoder(DiaConfig config, ScalarType computeDtype)
+        : base(nameof(Decoder))
+    {
+        var modelConfig = config.Model;
+        var dataConfig = config.Data;
+        _numChannels = dataConfig.Channels;
+        _numLayers = modelConfig.Decoder.NLayer;
+        _computeDtype = computeDtype;
+
+        embeddings = new();
+        for (int i = 0; i < _numChannels; i++)
+        {
+            embeddings.Add(Embedding(
+                num_embeddings: modelConfig.TgtVocabSize,
+                embedding_dims: modelConfig.Decoder.NEmbedding,
+                dtype: computeDtype
+            ));
+        }
+
+        layers = new();
+        for (int i = 0; i < _numLayers; i++)
+        {
+            layers.Add(new DecoderLayer(config, computeDtype));
+        }
+
+        norm = new RMSNorm(
+            normalizedShape: modelConfig.Decoder.NEmbedding,
+            eps: modelConfig.NormalizationLayerEpsilon,
+            elementwiseAffine: true,
+            dtype: ScalarType.Float32
+        );
+
+        logits_dense = new DenseGeneral(
+            inShapes: new[] { modelConfig.Decoder.NEmbedding },
+            outFeatures: new[] { _numChannels, modelConfig.TgtVocabSize },
+            axis: new[] { -1 },
+            weightDtype: computeDtype
+        );
+
+        RegisterComponents();
+    }
+
+    /// <summary>
+    /// Computes the Key and Value tensors for cross-attention for each layer from the encoder output.
+    /// </summary>
+    /// <param name="encOut">Encoder output tensor [B, S, E] - B=batch, S=source length, E=embedding dim</param>
+    /// <param name="encPositions">Encoder position indices [B, S]</param>
+    /// <param name="kPaddingMask"> Optional padding mask for keys [B, S]</param>
+    /// <returns>List of KVCache for each layer</returns>
+    public List<KVCache> PrecomputeCrossAttnCache(Tensor encOut, Tensor encPositions, Tensor? kPaddingMask = null)
+    {
+        using var scope = NewDisposeScope();
+
+        var perLayerKvCache = layers.Select(layer =>
+        {
+            var crossAttnModule = layer.CrossAttention;
+
+            // Project to key/value spaces
+            var kProj = crossAttnModule.k_proj.forward(encOut);
+            var vProj = crossAttnModule.v_proj.forward(encOut);
+
+            // Apply rotary embeddings to keys
+            var kEmb = crossAttnModule._rotaryEmb.forward(kProj, encPositions);
+
+            // Transpose for attention computation
+            var k = kEmb.transpose(1, 2);
+            var v = vProj.transpose(1, 2);
+
+            if (kPaddingMask is not null)
+            {
+                k = k.masked_fill(~kPaddingMask.unsqueeze(1).unsqueeze(3), 0.0);
+            }
+
+            return KVCache.FromKV(k.MoveToOuterDisposeScope(), v.MoveToOuterDisposeScope());
+        }).ToList();
+
+        return perLayerKvCache;
+    }
+
+    /// <summary>
+    /// Performs a single decoding step, managing KV caches layer by layer.
+    /// </summary>
+    /// <param name="tgtIds_Bx1xC">Target token IDs [B, 1, C] - B=batch, C=channels</param>
+    /// <param name="state">Decoder inference state</param>
+    /// <param name="currentIndex"></param>
+    /// <returns>Logits for the current step [B, 1, C, V] - V=vocab size</returns>
+    public Tensor DecodeStep(Tensor tgtIds_Bx1xC, DecoderInferenceState state, int currentIndex)
+    {
+        using var scope = NewDisposeScope();
+        Tensor x = null;
+
+        // Extract tokens, get embeddings, and sum them for each channel
+        for (int i = 0; i < _numChannels; i++)
+        {
+            var channelTokens = tgtIds_Bx1xC[TensorIndex.Ellipsis, i];
+            var channelEmbed = embeddings[i].forward(channelTokens);
+            x = x is null ? channelEmbed : x.add(channelEmbed);
+        }
+
+        // Process through decoder layers
+        for (int i = 0; i < layers.Count; i++)
+        {
+            var selfCache = state.SelfAttentionCache[i];
+            var crossCache = state.CrossAttentionCache[i];
+
+            x = layers[i].forward(
+                x!,
+                state,
+                selfAttnCache: selfCache,
+                crossAttnCache: crossCache,
+                currentIndex: currentIndex
+            );
+        }
+
+        // Final normalization and project to logits
+        x = norm.forward(x!);
+        var logits_Bx1xCxV = logits_dense.forward(x);
+
+        return logits_Bx1xCxV.to(_computeDtype).MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
+    /// Forward pass for the Decoder stack, managing KV caches.
+    /// </summary>
+    /// <param name="tgtIds_BxTxC">Target token IDs [B, T, C] - B=batch, T=time, C=channels</param>
+    /// <param name="state">Decoder inference state</param>
+    /// <returns>Logits [B, T, C, V] - V=vocab size</returns>
+    public override Tensor forward(Tensor tgtIds_BxTxC, DecoderInferenceState state)
+    {
+        using var scope = NewDisposeScope();
+        var numChannelsIn = tgtIds_BxTxC.size(-1);
+        if (numChannelsIn != _numChannels)
+        {
+            throw new ArgumentException($"Input channels mismatch. Expected {_numChannels}, got {numChannelsIn}");
+        }
+
+        Tensor x = null;
+
+        // Extract tokens, get embeddings, and sum them for each channel
+        for (int i = 0; i < _numChannels; i++)
+        {
+            var channelTokens = tgtIds_BxTxC[TensorIndex.Ellipsis, i];
+            var channelEmbed = embeddings[i].forward(channelTokens);
+            x = x is null ? channelEmbed : x.add(channelEmbed);
+        }
+
+        // Process through decoder layers
+        for (int i = 0; i < _numLayers; i++)
+        {
+            var selfCache = state.SelfAttentionCache[i];
+            var crossCache = state.CrossAttentionCache[i];
+
+            x = layers[i].forward(
+                x!,
+                state,
+                selfAttnCache: selfCache,
+                crossAttnCache: crossCache,
+                prefill: true
+            );
+        }
+
+        // Final normalization and project to logits
+        x = norm.forward(x!);
+        var logits_BxTxCxV = logits_dense.forward(x);
+
+        return logits_BxTxCxV.to(_computeDtype).MoveToOuterDisposeScope();
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            embeddings?.Dispose();
+            layers?.Dispose();
+            norm?.Dispose();
+            logits_dense?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/DecoderInferenceState.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/DecoderInferenceState.cs
@@ -1,0 +1,193 @@
+using NeuralCodecs.Torch.Config.Dia;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Parameters specifically for decoder inference.
+/// </summary>
+public class DecoderInferenceState : Module
+{
+    /// <summary>
+    /// Device for tensor operations.
+    /// </summary>
+    public Device Device { get; }
+
+    /// <summary>
+    /// Data type for computation.
+    /// </summary>
+    public ScalarType Dtype { get; }
+
+    /// <summary>
+    /// Encoder output (shape: [B, S, E])
+    /// B=2 (unconditional + conditional paths)
+    /// S=source sequence length
+    /// E=embedding dimension
+    /// </summary>
+    public Tensor EncoderOutput { get; }
+
+    /// <summary>
+    /// Encoder positions (shape: [B, S])
+    /// Position indices for source sequence
+    /// </summary>
+    public Tensor EncoderPositions { get; }
+
+    /// <summary>
+    /// Decoder positions (shape: [B, T])
+    /// Position indices for target sequence
+    /// T varies dynamically during decoding
+    /// </summary>
+    public Tensor DecoderPositions { get; private set; }
+
+    /// <summary>
+    /// Self-attention cache for each decoder layer.
+    /// </summary>
+    public List<KVCache> SelfAttentionCache { get; }
+
+    /// <summary>
+    /// Cross-attention cache for each decoder layer.
+    /// </summary>
+    public List<KVCache> CrossAttentionCache { get; }
+
+    /// <summary>
+    /// Causal attention mask used to enforce autoregressive behavior in sequence processing.
+    /// </summary>
+    public Tensor CausalAttentionMask { get; }
+
+    /// <summary>
+    /// Cross-attention mask for decoder-encoder attention.
+    /// </summary>
+    public Tensor CrossAttentionMask { get; }
+
+    private DecoderInferenceState(
+        Device device,
+        ScalarType dtype,
+        Tensor encoderOutput,
+        Tensor encoderPositions,
+        Tensor decoderPositions,
+        List<KVCache> selfAttentionCache,
+        List<KVCache> crossAttentionCache,
+        Tensor causalAttentionMask,
+        Tensor crossAttentionMask)
+        : base(nameof(DecoderInferenceState))
+    {
+        Device = device;
+        Dtype = dtype;
+        EncoderOutput = encoderOutput;
+        EncoderPositions = encoderPositions;
+        DecoderPositions = decoderPositions;
+        SelfAttentionCache = selfAttentionCache;
+        CrossAttentionCache = crossAttentionCache;
+        CausalAttentionMask = causalAttentionMask;
+        CrossAttentionMask = crossAttentionMask;
+    }
+
+    /// <summary>
+    /// Creates a new DecoderInferenceState from the given configuration and encoder state.
+    /// </summary>
+    /// <param name="config">Model configuration</param>
+    /// <param name="encoderState">Encoder inference state</param>
+    /// <param name="encoderOutput">Encoder output tensor</param>
+    /// <param name="decoderCrossAttentionCache">Cross-attention cache for each decoder layer</param>
+    /// <param name="computeType">Computation data type</param>
+    /// <param name="maxGenerationLength">Maximum generation length (optional)</param>
+    /// <returns>New DecoderInferenceState</returns>
+    public static DecoderInferenceState New(
+        DiaConfig config,
+        EncoderInferenceState encoderState,
+        Tensor encoderOutput,
+        List<KVCache> decoderCrossAttentionCache,
+        ScalarType computeType,
+        int? maxGenerationLength = null)
+    {
+        var device = encoderOutput.device;
+        var maxAudioLen = maxGenerationLength ?? config.Data.AudioLength;
+        var batchSize = (int)encoderOutput.shape[0] / 2;
+
+        // Create decoder positions [B, 1] - initial position 0
+        var decoderPositions = full([2 * batchSize, 1], 0, ScalarType.Int32, device: device);
+        var causalMask = tril(ones([maxAudioLen, maxAudioLen], ScalarType.Bool, device: device));
+
+        // Create cross-attention mask
+        var decMask = ones([2 * batchSize, 1], dtype: ScalarType.Bool, device: device);
+        var crossAttnMask = AttentionMaskUtils.CreateAttentionMask(decMask, encoderState.PaddingMask, device, isCausal: false);
+
+        // Create self-attention cache for each decoder layer
+        var selfAttentionCache = new List<KVCache>();
+        for (int i = 0; i < config.Model.Decoder.NLayer; i++)
+        {
+            selfAttentionCache.Add(new KVCache(
+                batchSize,
+                config.Model.Decoder.KvHeads,
+                maxAudioLen,
+                config.Model.Decoder.GqaHeadDim,
+                computeType,
+                device));
+        }
+
+        return new DecoderInferenceState(
+            device: device,
+            dtype: computeType,
+            encoderOutput: encoderOutput,
+            encoderPositions: encoderState.Positions,
+            decoderPositions: decoderPositions,
+            selfAttentionCache: selfAttentionCache,
+            crossAttentionCache: decoderCrossAttentionCache,
+            causalAttentionMask: causalMask,
+            crossAttentionMask: crossAttnMask);
+    }
+
+    /// <summary>
+    /// Prepares the decoder state for a specific decoding step.
+    /// </summary>
+    /// <param name="stepFrom">Starting step index</param>
+    /// <param name="stepTo">Optional ending step index (defaults to stepFrom + 1)</param>
+    public void PrepareStep(int stepFrom, int? stepTo = null)
+    {
+        stepTo ??= stepFrom + 1;
+
+        // Dispose previous positions tensor to prevent memory leaks
+        DecoderPositions?.Dispose();
+
+        DecoderPositions = arange(stepFrom, stepTo, dtype: int32, device: Device)
+            .unsqueeze_(0);
+    }
+
+    /// <summary>
+    /// Moves the current instance and its associated resources to the outer disposal scope.
+    /// </summary>
+    /// <remarks>This method ensures that the resources managed by the current instance, including
+    /// <see cref="EncoderOutput"/>, <see cref="EncoderPositions"/>, and <see cref="DecoderPositions"/>, are moved
+    /// to the outer disposal scope. The Cache tensors are not moved, as they should be detached from the current scope.
+    /// </remarks>
+    /// <returns>The current <see cref="DecoderInferenceState"/> instance, allowing for method chaining.</returns>
+    public DecoderInferenceState MoveToOuterDisposeScope()
+    {
+        EncoderOutput.MoveToOuterDisposeScope();
+        EncoderPositions.MoveToOuterDisposeScope();
+        DecoderPositions.MoveToOuterDisposeScope();
+        CrossAttentionMask.MoveToOuterDisposeScope();
+        // cache should be detached from the current scope
+        return this;
+    }
+
+    /// <summary>
+    /// Releases resources used by this instance
+    /// </summary>
+    /// <param name="disposing">True when called from Dispose, false when called from finalizer</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            // Dispose tensors
+            EncoderOutput?.Dispose();
+            EncoderPositions?.Dispose();
+            DecoderPositions?.Dispose();
+            CrossAttentionMask?.Dispose();
+            // Don't dispose cross-attention cache as it might be shared
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/DecoderLayer.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/DecoderLayer.cs
@@ -1,0 +1,180 @@
+using NeuralCodecs.Torch.Config.Dia;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Transformer Decoder Layer using DenseGeneral.
+/// </summary>
+public class DecoderLayer : Module<Tensor, DecoderInferenceState, KVCache?, KVCache?, bool, int, Tensor>
+{
+    private readonly RMSNorm pre_sa_norm;
+    private readonly SelfAttention self_attention;
+    private readonly RMSNorm pre_ca_norm;
+    private readonly CrossAttention cross_attention;
+    private readonly RMSNorm pre_mlp_norm;
+    private readonly MlpBlock mlp;
+    private readonly ScalarType _computeDtype;
+
+    /// <summary>
+    /// Gets the cross-attention module of this decoder layer.
+    /// </summary>
+    public CrossAttention CrossAttention => cross_attention;
+
+    /// <summary>
+    /// Creates a new DecoderLayer.
+    /// </summary>
+    /// <param name="config">Model configuration</param>
+    /// <param name="computeDtype">Computation data type</param>
+    public DecoderLayer(DiaConfig config, ScalarType computeDtype)
+        : base(nameof(DecoderLayer))
+    {
+        var modelConfig = config.Model;
+        var decConfig = config.Model.Decoder;
+        var encConfig = config.Model.Encoder;
+        var decEmbedDim = decConfig.NEmbedding;
+        var encEmbedDim = encConfig.NEmbedding;
+        _computeDtype = computeDtype;
+
+        // Normalization layers
+        pre_sa_norm = new RMSNorm(
+            normalizedShape: decEmbedDim,
+            eps: modelConfig.NormalizationLayerEpsilon,
+            elementwiseAffine: true,
+            dtype: ScalarType.Float32
+        );
+
+        pre_ca_norm = new RMSNorm(
+            normalizedShape: decEmbedDim,
+            eps: modelConfig.NormalizationLayerEpsilon,
+            elementwiseAffine: true,
+            dtype: ScalarType.Float32
+        );
+
+        pre_mlp_norm = new RMSNorm(
+            normalizedShape: decEmbedDim,
+            eps: modelConfig.NormalizationLayerEpsilon,
+            elementwiseAffine: true,
+            dtype: ScalarType.Float32
+        );
+
+        // Self-attention (GQA) with Causal Masking
+        self_attention = new SelfAttention(
+            config,
+            qEmbedDim: decEmbedDim,
+            kvEmbedDim: decEmbedDim,
+            numQueryHeads: decConfig.GqaQueryHeads,
+            numKvHeads: decConfig.KvHeads,
+            headDim: decConfig.GqaHeadDim,
+            computeDtype: computeDtype,
+            outEmbedDim: decEmbedDim
+        );
+
+        // Cross-attention (Multi-Head Attention)
+        cross_attention = new CrossAttention(
+            config,
+            qEmbedDim: decEmbedDim,
+            kvEmbedDim: encEmbedDim,
+            numQueryHeads: decConfig.CrossQueryHeads,
+            numKvHeads: decConfig.CrossQueryHeads,
+            headDim: decConfig.CrossHeadDim,
+            computeDtype: computeDtype,
+            outEmbedDim: decEmbedDim
+        );
+
+        mlp = new MlpBlock(
+            embedDim: decEmbedDim,
+            intermediateDim: decConfig.NHidden,
+            computeDtype: computeDtype
+        );
+
+        RegisterComponents();
+    }
+
+    /// <summary>
+    /// Processes the input tensor through the decoder, updating the inference state as needed.
+    /// </summary>
+    /// <param name="x">The input tensor to be processed by the decoder.</param>
+    /// <param name="state">The current inference state, which will be updated during processing.</param>
+    /// <returns>A tensor representing the output of the decoder after processing the input.</returns>
+    public Tensor forward(Tensor x, DecoderInferenceState state) =>
+        forward(x, state, null, null, false);
+
+    /// <summary>
+    /// Processes the input tensor through a decoder layer, applying self-attention, cross-attention,  and a
+    /// feed-forward network with pre-normalization at each stage.
+    /// </summary>
+    /// <param name="x">The input tensor to the decoder layer.</param>
+    /// <param name="state">The current decoder inference state, including positional information and attention masks.</param>
+    /// <param name="selfAttnCache">An optional cache for self-attention key-value pairs. </param>
+    /// <param name="crossAttnCache">An optional cache for cross-attention key-value pairs. </param>
+    /// <param name="prefill">A boolean value indicating whether the method is in prefill mode. If <see langword="true"/>,  causal masking
+    /// is applied during self-attention to ensure autoregressive behavior.</param>
+    /// <param name="currentIndex">The current decoding step index. This is used to select the appropriate positions and attention masks for
+    /// the current step in the decoding process.</param>
+    /// <returns>A tensor representing the output of the decoder layer after applying self-attention, cross-attention, and
+    /// the feed-forward network.</returns>
+    public override Tensor forward(
+        Tensor x,
+        DecoderInferenceState state,
+        KVCache? selfAttnCache,
+        KVCache? crossAttnCache,
+        bool prefill = false,
+        int currentIndex = 0)
+    {
+        using var scope = NewDisposeScope();
+        var residual = x;
+
+        var attnMask = state.CausalAttentionMask[TensorIndex.None, TensorIndex.None, currentIndex];
+        var xNorm = pre_sa_norm.forward(x).to(_computeDtype);
+
+        var saOut = self_attention.forward(
+            x: xNorm,
+            qPositions: state.DecoderPositions,
+            attnMask: attnMask,
+            cache: selfAttnCache,
+            prefill: prefill,
+            isCausal: prefill, // Only use causal masking during prefill
+            currentIdx: currentIndex
+        );
+
+        x = residual.add(saOut);
+
+        residual = x;
+        xNorm = pre_ca_norm.forward(x).to(_computeDtype);
+
+        // Updated cross-attention call to match new signature
+        var caOut = cross_attention.forward(
+            Xq: xNorm,
+            qPositions: state.DecoderPositions,
+            kvPositions: state.EncoderPositions,
+            attnMask: state.CrossAttentionMask,
+            cache: crossAttnCache
+        );
+
+        x = residual.add(caOut);
+
+        residual = x;
+        xNorm = pre_mlp_norm.forward(x).to(_computeDtype);
+        var mlpOut = mlp.forward(xNorm);
+        x = residual.add(mlpOut);
+
+        return x.MoveToOuterDisposeScope();
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            pre_sa_norm?.Dispose();
+            self_attention?.Dispose();
+            pre_ca_norm?.Dispose();
+            cross_attention?.Dispose();
+            pre_mlp_norm?.Dispose();
+            mlp?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/DecoderOutput.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/DecoderOutput.cs
@@ -1,0 +1,122 @@
+using NeuralCodecs.Torch.Config.Dia;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Container for decoder generation output.
+/// Manages token storage and manipulation during generation.
+/// </summary>
+public class DecoderOutput : Module
+{
+    /// <summary>
+    /// Generated token tensor (shape: [L, C])
+    /// where L is max audio length and C is number of channels
+    /// </summary>
+    public Tensor GeneratedTokens { get; }
+
+    /// <summary>
+    /// The step at which the prefill completes.
+    /// </summary>
+    public int[] PrefillSteps { get; private set; }
+
+    private DecoderOutput(Tensor generatedTokens) : base(nameof(DecoderOutput))
+    {
+        GeneratedTokens = generatedTokens;
+        PrefillSteps = [];
+    }
+
+    /// <summary>
+    /// Creates a new DecoderOutput with the specified configuration and device.
+    /// </summary>
+    /// <param name="batchSize"></param>
+    /// <param name="config">Model configuration</param>
+    /// <param name="device">Device for tensor operations</param>
+    /// <returns>New DecoderOutput</returns>
+    public static DecoderOutput New(int batchSize, DiaConfig config, Device device)
+    {
+        int maxAudioLen = config.Data.AudioLength;
+
+        // Initialize token tensor with -1 (uninitialized)
+        var generatedTokens = full(
+            new long[] { batchSize, maxAudioLen, config.Data.Channels },
+            -1,
+            ScalarType.Int32,
+            device: device);
+
+        return new DecoderOutput(generatedTokens);
+    }
+
+    /// <summary>
+    /// Gets tokens at the specified step range.
+    /// </summary>
+    /// <param name="stepFrom">Starting step index</param>
+    /// <param name="stepTo">Optional ending step index (defaults to stepFrom + 1)</param>
+    /// <returns>Tensor slice of tokens, shape [stepTo-stepFrom, C]</returns>
+    public Tensor GetTokensAt(int stepFrom, int? stepTo = null)
+    {
+        stepTo ??= stepFrom + 1;
+        var tokens = GeneratedTokens.index(TensorIndex.Colon, TensorIndex.Slice(stepFrom, stepTo), TensorIndex.Colon);
+
+        return tokens;
+    }
+
+    /// <summary>
+    /// Updates a single token in the output.
+    /// </summary>
+    /// <param name="decOut">New token tensor (shape: [C])</param>
+    /// <param name="step">Step index to update</param>
+    /// <param name="applyMask">Whether to apply masking for invalid tokens</param>
+    public void UpdateOne(Tensor decOut, int step, bool applyMask = false)
+    {
+        var dec = decOut.to(GeneratedTokens.dtype);
+        if (applyMask)
+        {
+            using var stepSlice = GeneratedTokens.index(TensorIndex.Colon, step, TensorIndex.Colon);
+            using var mask = stepSlice.eq(-1);
+            var updatedValues = where(mask, dec, stepSlice);
+
+            GeneratedTokens[TensorIndex.Colon, step, TensorIndex.Colon] = updatedValues;
+        }
+        else
+        {
+            GeneratedTokens[TensorIndex.Colon, step, TensorIndex.Colon] = dec;
+        }
+    }
+
+    /// <summary>
+    /// Prefills the output with initial tokens.
+    /// </summary>
+    /// <param name="decOut">Token tensor to prefill with (shape: [L, C])</param>
+    /// <param name="prefillSteps">The step (or steps if batching) at which the prefill completes</param>
+    public void Prefill(Tensor decOut, int[] prefillSteps)
+    {
+        var length = decOut.shape[1];
+        GeneratedTokens[TensorIndex.Colon, TensorIndex.Slice(stop:length), TensorIndex.Colon] = decOut.MoveToOuterDisposeScope();
+        PrefillSteps = prefillSteps;
+    }
+
+    /// <summary>
+    /// Moves the current instance's <see cref="GeneratedTokens"/> tensor to the outer dispose scope.
+    /// </summary>
+    /// <returns>The current <see cref="DecoderOutput"/> instance, allowing for method chaining.</returns>
+    public DecoderOutput MoveToOuterDisposeScope()
+    {
+        GeneratedTokens.MoveToOuterDisposeScope();
+        return this;
+    }
+
+    /// <summary>
+    /// Releases resources used by this instance
+    /// </summary>
+    /// <param name="disposing">True when called from Dispose, false when called from finalizer</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            GeneratedTokens?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/DenseGeneral.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/DenseGeneral.cs
@@ -1,0 +1,116 @@
+using TorchSharp.Modules;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// PyTorch equivalent of flax.linen.DenseGeneral with shapes defined at init.
+/// Enables arbitrary tensor contractions, not just matrix multiplication.
+/// </summary>
+public class DenseGeneral : Module<Tensor, Tensor>
+{
+    private readonly int[] _axis;
+    private readonly int[] _inShapes;
+    private readonly int[] _outFeatures;
+    public readonly Parameter weight;
+    private readonly Parameter _bias;
+
+    public int[] InShapes => _inShapes;
+    public int[] OutFeatures => _outFeatures;
+
+    /// <summary>
+    /// Creates a new DenseGeneral layer.
+    /// </summary>
+    /// <param name="inShapes">Sizes of the input dimensions specified by axis</param>
+    /// <param name="outFeatures">Shape of the output features (non-contracted dims)</param>
+    /// <param name="axis">Input axis or axes to contract (default: -1)</param>
+    /// <param name="weightDtype">Data type for weights</param>
+    /// <param name="device">Device for the layer</param>
+    public DenseGeneral(
+        int[] inShapes,
+        int[] outFeatures,
+        int[] axis = null,
+        ScalarType? weightDtype = null,
+        Device device = null)
+        : base(nameof(DenseGeneral))
+    {
+        _inShapes = inShapes ?? throw new ArgumentNullException(nameof(inShapes));
+        _outFeatures = outFeatures ?? throw new ArgumentNullException(nameof(outFeatures));
+        _axis = axis ?? [-1];
+        device ??= CPU;
+        weightDtype ??= ScalarType.Float32;
+
+        // Calculate kernel shape (inShapes + outFeatures)
+        var kernelShape = new long[_inShapes.Length + _outFeatures.Length];
+        for (int i = 0; i < _inShapes.Length; i++)
+        {
+            kernelShape[i] = _inShapes[i];
+        }
+        for (int i = 0; i < _outFeatures.Length; i++)
+        {
+            kernelShape[_inShapes.Length + i] = _outFeatures[i];
+        }
+
+        weight = Parameter(empty(kernelShape, dtype: weightDtype, device: device));
+        RegisterComponents();
+    }
+
+    /// <summary>
+    /// Normalizes the specified axes to ensure all values are non-negative and within the range of dimensions.
+    /// </summary>
+    /// <param name="axes">An array of integers representing the axes to normalize. Negative values are interpreted as offsets from the
+    /// end of the dimensions.</param>
+    /// <param name="ndim">The total number of dimensions. Must be a positive value.</param>
+    /// <returns>An array of long integers where each value corresponds to a normalized axis, guaranteed to be in the range
+    /// [0, <paramref name="ndim"/> - 1].</returns>
+    public static long[] NormalizeAxes(int[] axes, long ndim)
+    {
+        var result = new long[axes.Length];
+        for (int i = 0; i < axes.Length; i++)
+        {
+            result[i] = axes[i] >= 0 ? axes[i] : ndim + axes[i];
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Applies a tensor contraction operation between the input tensor and the weight tensor along specified axes.
+    /// </summary>
+    /// <remarks>This method performs a generalized tensor contraction (similar to a matrix
+    /// multiplication) between the input tensor and the weight tensor.  The axes for contraction are determined by
+    /// the <c>_axis</c> field for the input tensor and the corresponding axes of the weight tensor.</remarks>
+    /// <param name="inputs">The input tensor to be processed. Must have dimensions compatible with the weight tensor along the specified
+    /// axes.</param>
+    /// <returns>A tensor resulting from the contraction of the input tensor with the weight tensor. The resulting tensor has
+    /// the same data type as the input tensor.</returns>
+    public override Tensor forward(Tensor inputs)
+    {
+        var normAxis = NormalizeAxes(_axis, inputs.dim());
+
+        var kernelContractAxes = new long[normAxis.Length];
+        for (int i = 0; i < normAxis.Length; i++)
+        {
+            kernelContractAxes[i] = i;
+        }
+        var output = tensordot(
+            inputs.to(weight.dtype),
+            weight,
+            dims1: normAxis,
+            dims2: kernelContractAxes
+        );
+
+        return output.to(inputs.dtype);
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            weight?.Dispose();
+            _bias?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/DiaModel.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/DiaModel.cs
@@ -1,0 +1,137 @@
+using NeuralCodecs.Core;
+using NeuralCodecs.Core.Configuration;
+using NeuralCodecs.Core.Loading;
+using NeuralCodecs.Core.Utils;
+using NeuralCodecs.Torch.Config.Dia;
+using NeuralCodecs.Torch.Utils;
+using TorchSharp;
+using TorchSharp.PyBridge;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+public class DiaModel : Module<Tensor, EncoderInferenceState, Tensor>, INeuralCodec
+{
+    private readonly DiaConfig _config;
+    private readonly Encoder encoder;
+    private readonly Decoder decoder;
+    private Device _device;
+
+    public DiaModel(DiaConfig config) : this(config, ScalarType.Float32, TorchUtils.GetDevice(config.Device))
+    {
+    }
+
+    /// <summary>
+    /// Creates a new Dia model.
+    /// </summary>
+    /// <param name="config">Model configuration</param>
+    /// <param name="computeDtype">Computation data type</param>
+    public DiaModel(DiaConfig config, ScalarType computeDtype, Device device)
+        : base(nameof(DiaModel))
+    {
+        _config = config;
+        encoder = new Encoder(config, computeDtype);
+        decoder = new Decoder(config, computeDtype);
+        _device = device;
+        RegisterComponents();
+    }
+
+    /// <summary>
+    /// Gets the encoder component of the Dia model.
+    /// </summary>
+    public Encoder Encoder => encoder;
+
+    /// <summary>
+    /// Gets the decoder component of the Dia model.
+    /// </summary>
+    public Decoder Decoder => decoder;
+
+    /// <summary>
+    /// Gets the model configuration.
+    /// </summary>
+    public IModelConfig Config => _config;
+
+    /// <summary>
+    /// Processes the input tensor through the encoder and returns the resulting tensor.
+    /// </summary>
+    /// <param name="x">The input tensor to be processed by the encoder.</param>
+    /// <param name="state">The inference state used to manage the encoder's internal state during processing.</param>
+    /// <returns>A tensor representing the output of the encoder after processing the input tensor.</returns>
+    public override Tensor forward(Tensor x, EncoderInferenceState state) => encoder.forward(x, state);
+
+    /// <summary>
+    /// Loads model weights from the specified file path.
+    /// </summary>
+    /// <remarks>This method supports multiple file formats, including PyTorch, SafeTensors, and
+    /// Checkpoint files. If the model is not currently on the CPU, it will temporarily move to the CPU for
+    /// loading. After loading, the model will be moved back to its configured device, if applicable.</remarks>
+    /// <param name="path">The file path to the weights file. The file must exist and be in a supported format.</param>
+    /// <exception cref="FileNotFoundException">Thrown if the file specified by <paramref name="path"/> does not exist.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if an error occurs while loading the weights, such as an
+    /// unsupported file format or a failure during processing.</exception>
+    public void LoadWeights(string path)
+    {
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"Weights not found at {path}");
+        }
+
+        try
+        {
+            set_default_device(CPU);
+            if (_device != CPU)
+            {
+                using (no_grad())
+                {
+                    this.to(CPU);
+                }
+            }
+
+            switch (FileUtils.DetectFileType(path))
+            {
+                case ModelFileType.PyTorch:
+                case ModelFileType.Weights:
+                    this.load_py(path);
+                    break;
+
+                case ModelFileType.SafeTensors:
+                    this.load_safetensors(path);
+                    break;
+
+                case ModelFileType.Checkpoint:
+                    this.load_checkpoint(path);
+                    break;
+
+                default:
+                    load(path, false);
+                    break;
+            }
+
+            if (_device != CPU)
+            {
+                using (no_grad())
+                {
+                    this.to(_device);
+                    set_default_device(_device);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException($"Failed to load weights from {path}: {ex.Message}", ex);
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            encoder.Dispose();
+            decoder.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/Encoder.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/Encoder.cs
@@ -1,0 +1,95 @@
+using NeuralCodecs.Torch.Config.Dia;
+using TorchSharp.Modules;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Transformer Encoder Stack.
+/// Processes text input through multiple transformer encoder layers.
+/// Each layer consists of self-attention and feed-forward components.
+/// </summary>
+public class Encoder : Module<Tensor, EncoderInferenceState, Tensor>
+{
+    private readonly Embedding embedding;
+    private readonly ModuleList<EncoderLayer> layers;
+    private readonly RMSNorm norm;
+    private readonly ScalarType _computeDtype;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Encoder"/> class, which represents the encoder component of a
+    /// transformer-based model.
+    /// </summary>
+    /// <param name="config">The configuration object containing model and encoder-specific settings,
+    /// such as vocabulary size, embedding dimensions, and number of layers.</param>
+    /// <param name="computeDtype">The data type used for computations, such as <see cref="ScalarType.Float32"/>
+    /// or <see cref="ScalarType.Float16"/>.</param>
+    public Encoder(DiaConfig config, ScalarType computeDtype)
+        : base(nameof(Encoder))
+    {
+        var modelConfig = config.Model;
+        var encConfig = config.Model.Encoder;
+        _computeDtype = computeDtype;
+
+        embedding = Embedding(
+            num_embeddings: modelConfig.SrcVocabSize,
+            embedding_dims: encConfig.NEmbedding,
+            device: Utils.TorchUtils.GetDevice( config.Device),
+            dtype: computeDtype
+
+        );
+
+        layers = new();
+        for (int i = 0; i < encConfig.NLayer; i++)
+        {
+            layers.Add(new EncoderLayer(config, computeDtype));
+        }
+
+        norm = new RMSNorm(
+            encConfig.NEmbedding,
+            eps: modelConfig.NormalizationLayerEpsilon,
+            elementwiseAffine: true,
+            dtype: ScalarType.Float32
+        );
+
+        RegisterComponents();
+    }
+
+    /// <summary>
+    /// Processes the input tensor through the embedding layer, a sequence of transformer layers,
+    /// and a normalization layer, producing the final output tensor.
+    /// </summary>
+    /// <param name="xIds">A tensor containing input token IDs  used to look up embeddings in the
+    /// embedding layer.</param>
+    /// <param name="state">The inference state used to maintain context across transformer layers.</param>
+    /// <returns>A tensor representing the processed output after applying the embedding, transformer layers,
+    /// and normalization. The output tensor is in the specified compute data type.</returns>
+    public override Tensor forward(Tensor xIds, EncoderInferenceState state)
+    {
+        using var scope = NewDisposeScope();
+
+        var x = embedding.forward(xIds);
+
+        for (int i = 0; i < layers.Count; i++)
+        {
+            x = layers[i].forward(x, state);
+        }
+        x = norm.forward(x).to(_computeDtype);
+
+        return x.MoveToOuterDisposeScope();
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            embedding?.Dispose();
+            layers?.Dispose();
+            norm?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/EncoderInferenceState.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/EncoderInferenceState.cs
@@ -1,0 +1,101 @@
+using NeuralCodecs.Torch.Config.Dia;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Parameters specifically for encoder inference.
+/// Manages state required for encoding text input in both conditional and unconditional paths.
+/// </summary>
+public class EncoderInferenceState : Module
+{
+    /// <summary>
+    /// Maximum sequence length.
+    /// </summary>
+    public int MaxSequenceLength { get; }
+
+    /// <summary>
+    /// Device for tensor operations.
+    /// </summary>
+    public Device Device { get; }
+
+    /// <summary>
+    /// Position indices (shape: [B, S])
+    /// B=2 (unconditional + conditional paths)
+    /// S=source text sequence length
+    /// Contains position IDs from 0 to S-1
+    /// </summary>
+    public Tensor Positions { get; }
+
+    /// <summary>
+    /// Padding mask (shape: [B, S])
+    /// Boolean tensor where True indicates valid tokens, False for padding
+    /// Used to mask out padding tokens during attention
+    /// </summary>
+    public Tensor PaddingMask { get; }
+
+    /// <summary>
+    /// Attention mask (shape: [B, 1, S, S])
+    /// Combines padding information into attention-compatible format
+    /// Value -inf for masked positions, 0 for valid positions
+    /// </summary>
+    public Tensor AttentionMask { get; }
+
+    internal EncoderInferenceState(
+        int maxSequenceLength,
+        Device device,
+        Tensor positions,
+        Tensor paddingMask,
+        Tensor attentionMask) : base(nameof(EncoderInferenceState))
+    {
+        MaxSequenceLength = maxSequenceLength;
+        Device = device;
+        Positions = positions;
+        PaddingMask = paddingMask;
+        AttentionMask = attentionMask;
+    }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="EncoderInferenceState"/> configured for the specified input data and device.
+    /// </summary>
+    /// <remarks>The method initializes the encoder inference state by calculating positional encodings,  padding
+    /// masks, and attention masks based on the provided configuration and input tensor.  The resulting state is ready for
+    /// use in encoder-based inference tasks.</remarks>
+    /// <param name="config">The configuration object containing parameters such as text length and padding value.</param>
+    /// <param name="condSrc">A tensor representing the conditional source input. This tensor is used to determine the device,
+    /// padding mask, and other state initialization parameters.</param>
+    /// <returns>An initialized <see cref="EncoderInferenceState"/> object configured with the specified input data,  including
+    /// positional encodings, padding masks, and attention masks.</returns>
+    public static EncoderInferenceState New(DiaConfig config, Tensor condSrc)
+    {
+        var device = condSrc.device;
+        var textLength = config.Data.TextLength;
+
+        var positions = arange(textLength, dtype: float32, device: device).unsqueeze(0);
+        var paddingMask = (condSrc.squeeze(1) != config.Data.TextPadValue).to(device).repeat_interleave(2, dim: 0);
+
+        var attentionMask = AttentionMaskUtils.CreateAttentionMask(
+            paddingMask, paddingMask, device, isCausal: false);
+
+        return new EncoderInferenceState(
+            maxSequenceLength: textLength,
+            device: device,
+            positions: positions,
+            paddingMask: paddingMask,
+            attentionMask: attentionMask);
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            Positions?.Dispose();
+            PaddingMask?.Dispose();
+            AttentionMask?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/EncoderLayer.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/EncoderLayer.cs
@@ -1,0 +1,120 @@
+using NeuralCodecs.Torch.Config.Dia;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Transformer Encoder Layer using DenseGeneral.
+/// </summary>
+public class EncoderLayer : Module<Tensor, EncoderInferenceState, int, Tensor>
+{
+
+    private readonly RMSNorm pre_sa_norm;
+    private readonly SelfAttention self_attention;
+    private readonly RMSNorm post_sa_norm;
+    private readonly MlpBlock mlp;
+    private readonly int _embedDim;
+    private readonly ScalarType _computeDtype;
+
+    /// <summary>
+    /// Creates a new EncoderLayer.
+    /// </summary>
+    /// <param name="config">Model configuration</param>
+    /// <param name="computeDtype">Computation data type</param>
+    public EncoderLayer(DiaConfig config, ScalarType computeDtype)
+        : base(nameof(EncoderLayer))
+    {
+        var modelConfig = config.Model;
+        var encConfig = config.Model.Encoder;
+        _embedDim = encConfig.NEmbedding;
+        _computeDtype = computeDtype;
+
+        pre_sa_norm = new RMSNorm(
+            normalizedShape: _embedDim,
+            eps: modelConfig.NormalizationLayerEpsilon,
+            elementwiseAffine: true,
+            dtype: ScalarType.Float32
+        );
+
+        self_attention = new SelfAttention(
+            config,
+            qEmbedDim: _embedDim,
+            kvEmbedDim: _embedDim,
+            numQueryHeads: encConfig.NHead,
+            numKvHeads: encConfig.NHead,
+            headDim: encConfig.HeadDim,
+            computeDtype: computeDtype,
+            outEmbedDim: _embedDim
+        );
+
+        post_sa_norm = new RMSNorm(
+            normalizedShape: _embedDim,
+            eps: modelConfig.NormalizationLayerEpsilon,
+            elementwiseAffine: true,
+            dtype: ScalarType.Float32
+            );
+
+        mlp = new MlpBlock(
+            embedDim: _embedDim,
+            intermediateDim: encConfig.NHidden,
+            computeDtype: computeDtype
+        );
+
+        RegisterComponents();
+    }
+
+    /// <summary>
+    /// Processes the input tensor through the encoder layer, applying self-attention and a feed-forward network.
+    /// </summary>
+    /// <param name="x">The input tensor with shape [batch size, sequence length, embedding size].</param>
+    /// <param name="state">The encoder inference state, which provides positional information and attention masks.</param>
+    /// <param name="currIndex">The current index in the sequence being processed. Defaults to 0.</param>
+    /// <returns>A tensor with the same shape as the input, representing the output of the encoder layer after applying
+    /// self-attention and the feed-forward network.</returns>
+    /// <exception cref="ArgumentException">Thrown if the shape of <paramref name="x"/> does not match the expected shape  [batch size, sequence length,
+    /// embedding size].</exception>
+    public override Tensor forward(Tensor x, EncoderInferenceState state, int currIndex = 0)
+    {
+        using var scope = NewDisposeScope();
+        var expectedShape = new long[] { x.shape[0], x.shape[1], _embedDim };
+        if (!x.shape.SequenceEqual(expectedShape))
+        {
+            throw new ArgumentException($"Expected shape {string.Join(",", expectedShape)}, got {string.Join(",", x.shape)}");
+        }
+
+        var residual = x;
+
+        // Self-attention with pre-normalization
+        var xNorm = pre_sa_norm.forward(x).to(_computeDtype);
+
+        var saOut = self_attention.forward(
+            x: xNorm,
+            qPositions: state.Positions,
+            attnMask: state.AttentionMask,
+            currentIdx: currIndex
+        );
+        x = residual.add(saOut);
+
+        // MLP with pre-normalization
+        residual = x;
+        xNorm = post_sa_norm.forward(x.to(_computeDtype, non_blocking: true));
+        var mlpOut = mlp.forward(xNorm);
+        x = residual.add(mlpOut);
+
+        return x.MoveToOuterDisposeScope();
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            pre_sa_norm.Dispose();
+            self_attention.Dispose();
+            post_sa_norm.Dispose();
+            mlp.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/FusedQKV.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/FusedQKV.cs
@@ -1,0 +1,95 @@
+using TorchSharp.Modules;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Fused QKV projection layer for efficient attention computation.
+/// </summary>
+public class FusedQKV : Module<Tensor, (Tensor q, Tensor k, Tensor v)>
+{
+    private readonly int _numQHeads;
+    private readonly int _qHeadDim;
+    private readonly int _numKvHeads;
+    private readonly int _kvHeadDim;
+    private readonly int _qOutputDim;
+    private readonly int _kvOutputDim;
+    private readonly Linear _linear;
+
+    /// <summary>
+    /// Creates a new FusedQKV layer.
+    /// </summary>
+    /// <param name="inFeatures">Input feature dimension</param>
+    /// <param name="outFeatures">Total output feature dimension (q_dim + k_dim + v_dim)</param>
+    /// <param name="bias">Whether to use bias</param>
+    /// <param name="numQHeads">Number of query heads</param>
+    /// <param name="qHeadDim">Query head dimension</param>
+    /// <param name="numKvHeads">Number of key/value heads</param>
+    /// <param name="kvHeadDim">Key/value head dimension</param>
+    public FusedQKV(
+        int inFeatures,
+        int outFeatures,
+        bool bias = false,
+        int numQHeads = 1,
+        int qHeadDim = 1,
+        int numKvHeads = 1,
+        int kvHeadDim = 1)
+        : base(nameof(FusedQKV))
+    {
+        _numQHeads = numQHeads;
+        _qHeadDim = qHeadDim;
+        _numKvHeads = numKvHeads;
+        _kvHeadDim = kvHeadDim;
+        _qOutputDim = numQHeads * qHeadDim;
+        _kvOutputDim = numKvHeads * kvHeadDim;
+
+        _linear = Linear(inFeatures, outFeatures, hasBias: bias);
+        RegisterComponents();
+    }
+
+    /// <summary>
+    /// Forward pass that splits output into Q, K, V tensors.
+    /// </summary>
+    /// <param name="inputs">Input tensor [B, T, D]</param>
+    /// <returns>Tuple of (Q, K, V) tensors</returns>
+    public override (Tensor q, Tensor k, Tensor v) forward(Tensor inputs)
+    {
+        using var scope = NewDisposeScope();
+
+        var x = _linear.forward(inputs);
+
+        // Split into Q, K, V
+        var splits = x.split(new long[] { _qOutputDim, _kvOutputDim, _kvOutputDim }, dim: -1);
+        var q = splits[0];
+        var k = splits[1];
+        var v = splits[2];
+
+        // Reshape to include head dimensions
+        var qShape = q.shape[..^1].Append(_numQHeads).Append(_qHeadDim).ToArray();
+        var kShape = k.shape[..^1].Append(_numKvHeads).Append(_kvHeadDim).ToArray();
+        var vShape = v.shape[..^1].Append(_numKvHeads).Append(_kvHeadDim).ToArray();
+
+        var qr = q.reshape(qShape);
+        var kr = k.reshape(kShape);
+        var vr = v.reshape(vShape);
+
+        return (qr.MoveToOuterDisposeScope(), kr.MoveToOuterDisposeScope(), vr.MoveToOuterDisposeScope());
+    }
+
+    /// <summary>
+    /// Gets the underlying linear layer for weight access.
+    /// </summary>
+    public Linear Linear => _linear;
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _linear?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/KVCache.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/KVCache.cs
@@ -1,0 +1,105 @@
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Key-Value cache for attention layers.
+/// </summary>
+public class KVCache : Module
+{
+    /// <summary>
+    /// Key cache (shape: [B, H, L, D])
+    /// </summary>
+    public Tensor K { get; private set; }
+
+    /// <summary>
+    /// Value cache (shape: [B, H, L, D])
+    /// </summary>
+    public Tensor V { get; private set; }
+
+    /// <summary>
+    /// Creates a new KVCache with the specified dimensions.
+    /// </summary>
+    /// <param name="batchSize"></param>
+    /// <param name="numHeads">Number of attention heads</param>
+    /// <param name="maxLen">Maximum sequence length</param>
+    /// <param name="headDim">Dimension of each head</param>
+    /// <param name="dtype">Data type for the cache</param>
+    /// <param name="device">Device for the cache</param>
+    /// <param name="k">Optional existing key cache</param>
+    /// <param name="v">Optional existing value cache</param>
+    public KVCache(
+        int batchSize,
+        int numHeads,
+        int maxLen,
+        int headDim,
+        ScalarType dtype,
+        Device device,
+        Tensor? k = null,
+        Tensor? v = null) : base("KVCache")
+    {
+        K = k ?? zeros([2 * batchSize, numHeads, maxLen, headDim], dtype: dtype, device: device);
+        V = v ?? zeros([2 * batchSize, numHeads, maxLen, headDim], dtype: dtype, device: device);
+        register_buffer("k", K);
+        register_buffer("v", V);
+    }
+
+    /// <summary>
+    /// Creates a KVCache from existing key and value tensors.
+    /// </summary>
+    /// <param name="k">Key tensor</param>
+    /// <param name="v">Value tensor</param>
+    /// <returns>New KVCache</returns>
+    public static KVCache FromKV(Tensor k, Tensor v)
+    {
+        return new KVCache(
+            batchSize: (int)(k.shape[0] / 2),
+            numHeads: (int)k.shape[1],
+            maxLen: (int)k.shape[2],
+            headDim: (int)k.shape[3],
+            dtype: k.dtype,
+            device: k.device,
+            k: k,
+            v: v);
+    }
+
+    /// <summary>
+    /// Updates the cache with new key and value tensors.
+    /// </summary>
+    /// <param name="k">New key tensor (shape: [B, H, 1, D])</param>
+    /// <param name="v">New value tensor (shape: [B, H, 1, D])</param>
+    /// <param name="currentIdx">Current cache index</param>
+    /// <returns>Tuple of updated key and value caches</returns>
+    public (Tensor kCache, Tensor vCache) Update(Tensor k, Tensor v, int? currentIdx)
+    {
+        var index = currentIdx is null ? TensorIndex.None : TensorIndex.Slice(currentIdx.Value, currentIdx.Value + 1);
+        K[TensorIndex.Colon, TensorIndex.Colon, index, TensorIndex.Colon] = k;
+        V[TensorIndex.Colon, TensorIndex.Colon, index, TensorIndex.Colon] = v;
+        return (K, V);
+    }
+
+    /// <summary>
+    /// Prefills the cache with initial key and value tensors.
+    /// </summary>
+    /// <param name="k">Key tensor to prefill with (shape: [B, H, T, D])</param>
+    /// <param name="v">Value tensor to prefill with (shape: [B, H, T, D])</param>
+    /// <returns>Tuple of the prefilled key and value tensors</returns>
+    public void Prefill(Tensor k, Tensor v)
+    {
+        var prefillLen = k.size(2);
+        K[TensorIndex.Colon, TensorIndex.Colon, TensorIndex.Slice(stop: prefillLen), TensorIndex.Colon] = k;
+        V[TensorIndex.Colon, TensorIndex.Colon, TensorIndex.Slice(stop: prefillLen), TensorIndex.Colon] = v;
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            K?.Dispose();
+            V?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/KVCacheExtensions.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/KVCacheExtensions.cs
@@ -1,0 +1,45 @@
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+public static class KVCacheExtensions
+{
+    /// <summary>
+    /// Disposes all caches in a collection
+    /// </summary>
+    /// <param name="caches">The collection of caches to dispose</param>
+    public static void Dispose(this List<KVCache> caches)
+    {
+        foreach (var cache in caches)
+        {
+            cache?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Clones all caches in a collection
+    /// </summary>
+    /// <param name="caches">The collection of caches to clone</param>
+    public static List<KVCache> Clone(this List<KVCache> caches)
+    {
+        var cloned = new List<KVCache>();
+        foreach (var cache in caches)
+        {
+            var k = cache.K.clone();
+            var v = cache.V.clone();
+            cloned.Add(KVCache.FromKV(k, v));
+        }
+        return cloned;
+    }
+
+    /// <summary>
+    /// Resets all caches in a collection, calling zero_ on each cache's K and V tensors.
+    /// </summary>
+    /// <param name="caches">The collection of caches to reset</param>
+    public static void Reset(this List<KVCache> caches)
+    {
+        foreach (var cache in caches)
+        {
+            cache?.K?.zero_();
+            cache?.V?.zero_();
+        }
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/MlpBlock.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/MlpBlock.cs
@@ -1,0 +1,82 @@
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+using static TorchSharp.torch.nn.functional;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// MLP block with SiLU gating.
+/// </summary>
+public class MlpBlock : Module<Tensor, Tensor>
+{
+    private readonly ScalarType _dtype;
+    private readonly int _intermediateDim;
+    private readonly DenseGeneral wi_fused;
+    private readonly DenseGeneral wo;
+
+    /// <summary>
+    /// Creates a new MLP block.
+    /// </summary>
+    /// <param name="embedDim">Embedding dimension</param>
+    /// <param name="intermediateDim">Intermediate dimension</param>
+    /// <param name="computeDtype">Computation data type</param>
+    public MlpBlock(int embedDim, int intermediateDim, ScalarType computeDtype)
+        : base(nameof(MlpBlock))
+    {
+        _dtype = computeDtype;
+        _intermediateDim = intermediateDim;
+        // Fused input projection (for gate and up projection)
+        wi_fused = new DenseGeneral(
+            inShapes: new[] { embedDim },
+            outFeatures: new[] { 2, intermediateDim },
+            axis: new[] { -1 },
+            weightDtype: computeDtype
+        );
+
+        // Output projection
+        wo = new DenseGeneral(
+            inShapes: new[] { intermediateDim },
+            outFeatures: new[] { embedDim },
+            axis: new[] { -1 },
+            weightDtype: computeDtype
+        );
+
+        RegisterComponents();
+    }
+
+    /// <summary>
+    /// Processes the input tensor through a series of transformations, including a fused projection,  activation,
+    /// and output projection, to produce the final output tensor.
+    /// </summary>
+    /// <remarks>This method performs a fused projection to split the input into gate and up
+    /// components, applies the SiLU activation  function to the gate, multiplies it with the up component, and then
+    /// processes the result through an output projection.</remarks>
+    /// <param name="x">The input tensor to be processed. Must be compatible with the expected dimensions of the model.</param>
+    /// <returns>A tensor representing the transformed output after applying the fused projection, activation, and output
+    /// projection.</returns>
+    public override Tensor forward(Tensor x)
+    {
+        using var scope = NewDisposeScope();
+        var fusedX = wi_fused.forward(x);
+
+        // Split into gate and up projections
+        using var gate = fusedX.index(TensorIndex.Ellipsis, 0, TensorIndex.Colon);
+        using var up = fusedX.index(TensorIndex.Ellipsis, 1, TensorIndex.Colon);
+
+        Tensor hidden = mul(silu(gate), up).to(_dtype);
+        var output = wo.forward(hidden);
+
+        return output.MoveToOuterDisposeScope();
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            wi_fused?.Dispose();
+            wo?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/RMSNorm.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/RMSNorm.cs
@@ -1,0 +1,87 @@
+﻿using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+public class RMSNorm : Module<Tensor, Tensor>
+{
+    public readonly Tensor weight;
+    private readonly float _epsilon;
+    private readonly long[] _normalizedShape;
+    private readonly bool _elementwiseAffine;
+
+    public RMSNorm(long normalizedShape, float eps = 1e-6f, bool elementwiseAffine = true, ScalarType? dtype = null, Device? device = null)
+        : this(new long[] { normalizedShape }, eps, elementwiseAffine, dtype, device)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the RMSNorm class.
+    /// </summary>
+    /// <param name="normalizedShape">Feature dimension to normalize.</param>
+    /// <param name="eps">Small constant for numerical stability.</param>
+    /// <param name="elementwiseAffine">Whether to include a weight term (gamma).</param>
+    /// <param name="dtype">Data type for parameters.</param>
+    /// <param name="device">Device for the parameters.</param>
+    public RMSNorm(
+        long[] normalizedShape,
+        float eps = 1e-6f,
+        bool elementwiseAffine = true,
+        ScalarType? dtype = null,
+        Device? device = null) : base("RMSNorm")
+    {
+        _normalizedShape = normalizedShape;
+        _epsilon = eps;
+        _elementwiseAffine = elementwiseAffine;
+
+        if (elementwiseAffine)
+        {
+            weight = Parameter(empty(normalizedShape, device: device, dtype: dtype));
+        }
+
+        ResetParameters();
+    }
+
+    private void ResetParameters()
+    {
+        if (_elementwiseAffine)
+        {
+            init.ones_(weight);
+        }
+    }
+
+    /// <summary>
+    /// Normalizes the input tensor along the last dimension using Root Mean Square (RMS) normalization.
+    /// </summary>
+    /// <remarks>RMS normalization is performed by dividing the input tensor by the square root of the mean of its
+    /// squared values  along the last dimension, with a small epsilon added for numerical stability. If element-wise affine
+    /// transformation  is enabled, the normalized values are scaled by the <c>weight</c> parameter.</remarks>
+    /// <param name="input">The input tensor to be normalized. Must be a non-null tensor.</param>
+    /// <returns>A tensor with the same shape as the input, where the values are normalized along the last dimension. If element-wise
+    /// affine transformation is enabled, the result is scaled by the <c>weight</c> parameter.</returns>
+    public override Tensor forward(Tensor input)
+    {
+        using var scope = NewDisposeScope();
+        var inputSqr = input.pow(2);
+        var variance = inputSqr.mean([-1L], keepdim: true);
+        var rms = rsqrt(variance + _epsilon);
+        var normed = rms * input;
+
+        if (_elementwiseAffine)
+        {
+            normed *= weight;
+        }
+
+        return normed.MoveToOuterDisposeScope();
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            weight?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/RotaryEmbedding.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/RotaryEmbedding.cs
@@ -1,0 +1,128 @@
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Rotary Position Embedding (RoPE) implementation.
+/// </summary>
+public class RotaryEmbedding : Module<Tensor, Tensor, Tensor>
+{
+    private readonly int _embeddingDims;
+    private readonly int _minTimescale;
+    private readonly int _maxTimescale;
+    private readonly ScalarType _computeDtype;
+    private readonly Tensor _timescale;
+
+    /// <summary>
+    /// Creates a new RotaryEmbedding layer.
+    /// </summary>
+    /// <param name="embeddingDims">Embedding dimension (must be even)</param>
+    /// <param name="minTimescale">Minimum timescale</param>
+    /// <param name="maxTimescale">Maximum timescale</param>
+    /// <param name="dtype">Data type</param>
+    public RotaryEmbedding(
+        int embeddingDims,
+        int minTimescale = 1,
+        int maxTimescale = 10000,
+        ScalarType computeDtype = ScalarType.Float32,
+        Device? device = null)
+        : base(nameof(RotaryEmbedding))
+    {
+        if (embeddingDims % 2 != 0)
+        {
+            throw new ArgumentException("Embedding dim must be even for RoPE.");
+        }
+
+        _embeddingDims = embeddingDims;
+        _minTimescale = minTimescale;
+        _maxTimescale = maxTimescale;
+        _computeDtype = computeDtype;
+
+        var halfEmbeddingDim = embeddingDims / 2;
+        var fraction = 2.0f * arange(0, halfEmbeddingDim) / embeddingDims;
+
+        // Calculate timescales
+        _timescale = (_minTimescale * pow(
+            _maxTimescale / _minTimescale,
+            fraction
+        )).to(float32);
+
+        register_buffer("timescale", _timescale, persistent: false);
+    }
+
+    /// <summary>
+    /// Applies rotary position embedding to the input tensor.
+    /// </summary>
+    /// <param name="inputs">Input tensor to apply RoPE to (shape: [B, T, H] or [B, T, N, H])</param>
+    /// <param name="position">Position tensor (shape: [B, T])</param>
+    /// <returns>Tensor with rotary position embedding applied (same shape as input)</returns>
+    public override Tensor forward(Tensor inputs, Tensor position)
+    {
+        using var scope = NewDisposeScope();
+        var positionExpanded = position.unsqueeze(-1).unsqueeze(-1);
+        var sinusoidInp = positionExpanded.div(_timescale.to(position.device));
+
+        var sin = sinusoidInp.sin();
+        var cos = sinusoidInp.cos();
+
+        var floatInputs = inputs.to(float32);
+        var chunks = chunk(floatInputs, 2, dim: -1);
+        var firstHalf = chunks[0];
+        var secondHalf = chunks[1];
+
+        var firstPart = firstHalf.mul(cos).sub(secondHalf.mul(sin));
+        var secondPart = secondHalf.mul(cos).add(firstHalf.mul(sin));
+
+        // Concatenate rotated parts back together
+        var result = cat(
+            new[] { firstPart.to(_computeDtype), secondPart.to(_computeDtype) },
+            dim: -1
+        );
+
+        return result.MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
+    /// Applies rotary position embedding using precomputed sin and cos tensors.
+    /// This is an optimized version that avoids recomputing sin/cos for each call.
+    /// </summary>
+    /// <param name="inputs">Input tensor to apply RoPE to</param>
+    /// <param name="sin">Precomputed sin tensor</param>
+    /// <param name="cos">Precomputed cos tensor</param>
+    /// <returns>Tensor with rotary position embedding applied</returns>
+    public Tensor ApplyRope(Tensor inputs, Tensor sin, Tensor cos)
+    {
+        using var scope = NewDisposeScope();
+        var floatInputs = inputs.to(float32);
+        var chunks = chunk(floatInputs, 2, dim: -1);
+        var firstHalf = chunks[0];
+        var secondHalf = chunks[1];
+
+        var firstPart = (firstHalf * cos) - (secondHalf * sin);
+        var secondPart = (secondHalf * cos) + (firstHalf * sin);
+
+        var result = cat(
+            new[] { firstPart.to(_computeDtype), secondPart.to(_computeDtype) },
+            dim: -1
+        );
+
+        return result.MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
+    /// Gets the timescale tensor for external sin/cos computation.
+    /// </summary>
+    public Tensor Timescale => _timescale;
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _timescale?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Dia/SelfAttention.cs
+++ b/NeuralCodecs.Torch/Modules/Dia/SelfAttention.cs
@@ -1,0 +1,333 @@
+using NeuralCodecs.Torch.Config.Dia;
+using NeuralCodecs.Torch.Utils;
+using TorchSharp;
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Modules.Dia;
+
+/// <summary>
+/// Self-attention module with support for Grouped Query Attention (GQA) and fused QKV.
+/// </summary>
+public class SelfAttention : Module<Tensor, Tensor, int, Tensor>
+{
+    private readonly int _numQueryHeads;
+    private readonly int _numKvHeads;
+    private readonly int _headDim;
+    private readonly int _outputDim;
+    private readonly int _projectedQueryDim;
+    private readonly int _numGqaGroups;
+    private readonly int _kvEmbedDim;
+    private readonly int _qEmbedDim;
+    private readonly ScalarType _computeDtype;
+
+    /// <summary>
+    /// Query projection layer.
+    /// </summary>
+    public readonly DenseGeneral q_proj;
+
+    /// <summary>
+    /// Key projection layer.
+    /// </summary>
+    public readonly DenseGeneral k_proj;
+
+    /// <summary>
+    /// Value projection layer.
+    /// </summary>
+    public readonly DenseGeneral v_proj;
+
+    /// <summary>
+    /// Output projection layer.
+    /// </summary>
+    public readonly DenseGeneral o_proj;
+
+    /// <summary>
+    /// Rotary positional embedding layer.
+    /// </summary>
+    public readonly RotaryEmbedding _rotaryEmb;
+
+    /// <summary>
+    /// Fused QKV layer (optional, used when patched).
+    /// </summary>
+    public FusedQKV? _qkv;
+
+    /// <summary>
+    /// Whether fused QKV is enabled.
+    /// </summary>
+    public bool IsFusedQkv { get; private set; }
+
+    /// <summary>
+    /// Creates a new SelfAttention module.
+    /// </summary>
+    /// <param name="config">Model configuration</param>
+    /// <param name="qEmbedDim">Query embedding dimension</param>
+    /// <param name="kvEmbedDim">Key/value embedding dimension</param>
+    /// <param name="numQueryHeads">Number of query heads</param>
+    /// <param name="numKvHeads">Number of key/value heads</param>
+    /// <param name="headDim">Dimension per head</param>
+    /// <param name="computeDtype">Computation data type</param>
+    /// <param name="outEmbedDim">Output embedding dimension (if different from query)</param>
+    public SelfAttention(
+        DiaConfig config,
+        int qEmbedDim,
+        int kvEmbedDim,
+        int numQueryHeads,
+        int numKvHeads,
+        int headDim,
+        ScalarType computeDtype,
+        int? outEmbedDim = null)
+        : base(nameof(SelfAttention))
+    {
+        _numQueryHeads = numQueryHeads;
+        _numKvHeads = numKvHeads;
+        _headDim = headDim;
+        _outputDim = outEmbedDim ?? qEmbedDim;
+        _projectedQueryDim = numQueryHeads * headDim;
+        _computeDtype = computeDtype;
+        _kvEmbedDim = kvEmbedDim;
+        _qEmbedDim = qEmbedDim;
+
+        if (numQueryHeads % numKvHeads != 0)
+        {
+            throw new ArgumentException(
+                $"num_query_heads ({numQueryHeads}) must be divisible by num_kv_heads ({numKvHeads})");
+        }
+
+        _numGqaGroups = numQueryHeads / numKvHeads;
+
+        // Projection layers
+        q_proj = new DenseGeneral(
+            inShapes: new[] { qEmbedDim },
+            outFeatures: new[] { numQueryHeads, headDim },
+            axis: new[] { -1 },
+            weightDtype: computeDtype
+        );
+
+        k_proj = new DenseGeneral(
+            inShapes: new[] { kvEmbedDim },
+            outFeatures: new[] { numKvHeads, headDim },
+            axis: new[] { -1 },
+            weightDtype: computeDtype
+        );
+
+        v_proj = new DenseGeneral(
+            inShapes: new[] { kvEmbedDim },
+            outFeatures: new[] { numKvHeads, headDim },
+            axis: new[] { -1 },
+            weightDtype: computeDtype
+        );
+
+        o_proj = new DenseGeneral(
+            inShapes: new[] { numQueryHeads, headDim },
+            outFeatures: new[] { _outputDim },
+            axis: new[] { -2, -1 },
+            weightDtype: computeDtype
+        );
+
+        RegisterComponents();
+
+        // Create Rotary embeddings after registering components
+        _rotaryEmb = new RotaryEmbedding(
+            embeddingDims: headDim,
+            minTimescale: config.Model.RopeMinTimescale,
+            maxTimescale: config.Model.RopeMaxTimescale,
+            computeDtype: computeDtype
+        );
+
+        IsFusedQkv = false;
+    }
+
+    /// <summary>
+    /// Gets the linear weight from a DenseGeneral layer for fused QKV conversion.
+    /// </summary>
+    private Tensor GetLinearWeight(DenseGeneral dense)
+    {
+        using var scope = NewDisposeScope();
+
+        var wDg = dense.weight;
+
+        long outFeatures = 1;
+        long inputFeatures = 1;
+
+        foreach (var dim in dense.OutFeatures)
+        {
+            outFeatures *= dim;
+        }
+
+        foreach (var dim in dense.InShapes)
+        {
+            inputFeatures *= dim;
+        }
+
+        var wDgReshapedForLinearT = wDg.reshape(inputFeatures, outFeatures);
+        var linearWeight = wDgReshapedForLinearT.transpose(0, 1).contiguous();
+
+        return linearWeight.MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
+    /// Patches the module to use fused QKV for better performance.
+    /// </summary>
+    public void PatchFusedQkv()
+    {
+        using var scope = NewDisposeScope();
+
+        var qProjWeight = GetLinearWeight(q_proj);
+        var kProjWeight = GetLinearWeight(k_proj);
+        var vProjWeight = GetLinearWeight(v_proj);
+
+        _qkv = new FusedQKV(
+            _kvEmbedDim,
+            (_numQueryHeads * _headDim) + (2 * _numKvHeads * _headDim),
+            bias: false,
+            numQHeads: _numQueryHeads,
+            qHeadDim: _headDim,
+            numKvHeads: _numKvHeads,
+            kvHeadDim: _headDim
+        );
+
+        using (torch.no_grad())
+        {
+            var concatenatedWeight = cat(new[] { qProjWeight, kProjWeight, vProjWeight }, dim: 0);
+            _qkv.Linear.weight.copy_(concatenatedWeight.DetachFromDisposeScope());
+        }
+        IsFusedQkv = true;
+    }
+
+    /// <summary>
+    /// Repeats the key-value tensor along the head dimension by the specified number of repetitions.
+    /// </summary>
+    public static Tensor RepeatKV(Tensor x, int nRep)
+    {
+        if (nRep == 1)
+        {
+            return x;
+        }
+
+        var batchSize = x.shape[0];
+        var nKVHeads = x.shape[1];
+        var seqLen = x.shape[2];
+        var headDim = x.shape[3];
+
+        return WrappedTensorDisposeScope(() =>
+        {
+            var expanded = x.unsqueeze(2)
+                           .expand(batchSize, nKVHeads, nRep, seqLen, headDim);
+            return expanded.reshape(batchSize, nKVHeads * nRep, seqLen, headDim);
+        });
+    }
+
+    /// <summary>
+    /// Performs forward pass for self-attention.
+    /// </summary>
+    /// <param name="x">Input tensor [B, T, D]</param>
+    /// <param name="qPositions">Query positions [B, T]</param>
+    /// <param name="currentIndex">Current decoding step</param>
+    /// <returns>Attention output</returns>
+    public override Tensor forward(Tensor x, Tensor qPositions, int currentIndex)
+        => forward(x, qPositions, null, null, null, false, false, currentIndex);
+
+    /// <summary>
+    /// Performs self-attention with optional KV caching and rotary positional embeddings.
+    /// </summary>
+    /// <param name="x">Input tensor [batch_size, sequence_length, embedding_dim].</param>
+    /// <param name="qPositions">Query positions tensor.</param>
+    /// <param name="kvPositions">Key-value positions tensor. Defaults to <paramref name="qPositions"/> if null.</param>
+    /// <param name="attnMask">Optional attention mask tensor.</param>
+    /// <param name="cache">Optional KV cache for autoregressive decoding.</param>
+    /// <param name="prefill">Whether to prefill the KV cache.</param>
+    /// <param name="isCausal">Whether to apply causal masking.</param>
+    /// <param name="currentIdx">Current sequence index for cache updates (required when cache is used without prefill).</param>
+    /// <returns>Attention output tensor with the same dtype as input.</returns>
+    public Tensor forward(
+            Tensor x,
+            Tensor qPositions,
+            Tensor? kvPositions = null,
+            Tensor? attnMask = null,
+            KVCache? cache = null,
+            bool prefill = false,
+            bool isCausal = false,
+            int? currentIdx = null)
+    {
+        kvPositions ??= qPositions; // keeping for parity with python
+        var originalDtype = x.dtype;
+        using var scope = NewDisposeScope();
+
+        Tensor xqBxTxNxH, xkBxSxKxH, xvBxSxKxH;
+
+        if (IsFusedQkv)
+        {
+            var (qf, kf, vf) = _qkv!.forward(x);
+            xqBxTxNxH = qf;
+            xkBxSxKxH = kf;
+            xvBxSxKxH = vf;
+        }
+        else
+        {
+            xqBxTxNxH = q_proj.forward(x);
+            xkBxSxKxH = k_proj.forward(x);
+            xvBxSxKxH = v_proj.forward(x);
+        }
+
+        var position = qPositions.unsqueeze(-1).unsqueeze(-1);
+        var sinusoidInp = position / _rotaryEmb.Timescale.to(position.device);
+        var sin = torch.sin(sinusoidInp);
+        var cos = torch.cos(sinusoidInp);
+
+        xqBxTxNxH = _rotaryEmb.ApplyRope(xqBxTxNxH, sin, cos);
+        xkBxSxKxH = _rotaryEmb.ApplyRope(xkBxSxKxH, sin, cos);
+
+        var xqBxNxTxH = xqBxTxNxH.transpose(1, 2);
+        var xkBxKxSxH = xkBxSxKxH.transpose(1, 2);
+        var xvBxKxSxH = xvBxSxKxH.transpose(1, 2);
+
+        Tensor attnK, attnV;
+
+        if (cache is null)
+        {
+            attnK = xkBxKxSxH;
+            attnV = xvBxKxSxH;
+        }
+        else if (prefill)
+        {
+            attnK = xkBxKxSxH;
+            attnV = xvBxKxSxH;
+            cache.Prefill(attnK, attnV);
+        }
+        else
+        {
+            (attnK, attnV) = cache.Update(xkBxKxSxH, xvBxKxSxH, currentIdx);
+        }
+
+        Tensor attnOutput = AttentionUtils.ScaledDotProductAttention(
+            xqBxNxTxH,
+            attnK,
+            attnV,
+            attentionMask: isCausal ? null : attnMask,
+            isCausal: isCausal,
+            scale: 1.0f,
+            enableGqa: _numGqaGroups > 1,
+            gqaGroups: _numGqaGroups
+        );
+        var attnOutputTransposed = attnOutput.transpose(1, 2).contiguous();
+        var output = o_proj.forward(attnOutputTransposed);
+
+        return output.to(originalDtype).MoveToOuterDisposeScope();
+    }    
+    
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            q_proj?.Dispose();
+            k_proj?.Dispose();
+            v_proj?.Dispose();
+            o_proj?.Dispose();
+            _rotaryEmb?.Dispose();
+            _qkv?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/NeuralCodecs.Torch/Modules/Encodec/ArithmeticCoder.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/ArithmeticCoder.cs
@@ -1,241 +1,240 @@
 using static TorchSharp.torch;
 
-namespace NeuralCodecs.Torch.Modules.Encodec
+namespace NeuralCodecs.Torch.Modules.Encodec;
+
+/// <summary>
+/// Improved Arithmetic coder implementation for entropy coding.
+/// Follows the reference Python implementation closely for binary compatibility.
+/// </summary>
+public class ArithmeticCoder : IDisposable
 {
+    private readonly List<(long, long)> _debug;
+    private readonly BitPacker _packer;
+    private readonly int _totalRangeBits;
+    private bool _disposed;
+    private long _high;
+    private long _low;
+    private int _maxBit;
+
     /// <summary>
-    /// Improved Arithmetic coder implementation for entropy coding.
-    /// Follows the reference Python implementation closely for binary compatibility.
+    /// Initialize an arithmetic coder for compressing data to a stream
     /// </summary>
-    public class ArithmeticCoder : IDisposable
+    /// <param name="stream">Output stream for compressed data</param>
+    /// <param name="totalRangeBits">Total range bits, typically 24 (default) or less</param>
+    /// <exception cref="ArgumentException">Thrown when parameters are invalid</exception>
+    public ArithmeticCoder(Stream stream, int totalRangeBits = 24)
     {
-        private readonly List<(long, long)> _debug;
-        private readonly BitPacker _packer;
-        private readonly int _totalRangeBits;
-        private bool _disposed;
-        private long _high;
-        private long _low;
-        private int _maxBit;
+        ValidateParameters(stream, totalRangeBits);
 
-        /// <summary>
-        /// Initialize an arithmetic coder for compressing data to a stream
-        /// </summary>
-        /// <param name="stream">Output stream for compressed data</param>
-        /// <param name="totalRangeBits">Total range bits, typically 24 (default) or less</param>
-        /// <exception cref="ArgumentException">Thrown when parameters are invalid</exception>
-        public ArithmeticCoder(Stream stream, int totalRangeBits = 24)
+        _totalRangeBits = totalRangeBits;
+        _packer = new BitPacker(1, stream);
+        _low = 0;
+        _high = 0;
+        _maxBit = -1;
+        _debug = new List<(long, long)>();
+    }
+
+    /// <summary>
+    /// Gets the current range width
+    /// </summary>
+    public long Delta => _high - _low + 1;
+
+    /// <summary>
+    /// Gets the total range bits used for coding
+    /// </summary>
+    public int TotalRangeBits => _totalRangeBits;
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Flush any remaining bits to the stream
+    /// </summary>
+    public void Flush()
+    {
+        // Send any remaining bits in the low value
+        while (_maxBit >= 0)
         {
-            ValidateParameters(stream, totalRangeBits);
-
-            _totalRangeBits = totalRangeBits;
-            _packer = new BitPacker(1, stream);
-            _low = 0;
-            _high = 0;
-            _maxBit = -1;
-            _debug = new List<(long, long)>();
+            var bit = (_low >> _maxBit) & 1;
+            _packer.Push((int)bit);
+            _maxBit--;
         }
 
-        /// <summary>
-        /// Gets the current range width
-        /// </summary>
-        public long Delta => _high - _low + 1;
+        // Flush the bit packer to ensure all bits are written
+        _packer.Flush();
+    }
 
-        /// <summary>
-        /// Gets the total range bits used for coding
-        /// </summary>
-        public int TotalRangeBits => _totalRangeBits;
-
-        /// <inheritdoc/>
-        public void Dispose()
+    /// <summary>
+    /// Push a symbol to the stream using arithmetic coding
+    /// </summary>
+    /// <param name="symbol">Symbol to encode</param>
+    /// <param name="quantizedCdf">Quantized CDF for the symbol probability distribution</param>
+    /// <exception cref="ArgumentException">Thrown when CDF is invalid</exception>
+    /// <exception cref="InvalidOperationException">Thrown when coding state becomes invalid</exception>
+    public void Push(int symbol, Tensor quantizedCdf)
+    {
+        if (quantizedCdf is null || quantizedCdf.IsInvalid)
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            throw new ArgumentException("Quantized CDF must be valid", nameof(quantizedCdf));
         }
 
-        /// <summary>
-        /// Flush any remaining bits to the stream
-        /// </summary>
-        public void Flush()
+        if (symbol < 0 || symbol > quantizedCdf.shape[0] - 1)
         {
-            // Send any remaining bits in the low value
-            while (_maxBit >= 0)
+            throw new ArgumentException(
+                $"Symbol {symbol} out of range [0, {quantizedCdf.shape[0] - 1}]", nameof(symbol));
+        }
+
+        // Ensure our range is large enough, pushing bits as needed
+        while (Delta < (1L << TotalRangeBits))
+        {
+            _low *= 2;
+            _high = (_high * 2) + 1;
+            _maxBit++;
+        }
+
+        // Get range bounds for the symbol from the CDF
+        long rangeLow = symbol == 0 ? 0 : quantizedCdf[symbol - 1].item<long>();
+        long rangeHigh = quantizedCdf[symbol].item<long>() - 1;
+
+        // Scale the range to the current interval
+        double scale = Delta / (double)(1L << TotalRangeBits);
+        var effectiveLow = (long)Math.Ceiling(rangeLow * scale);
+        var effectiveHigh = (long)Math.Floor(rangeHigh * scale);
+
+        // Check for invalid range
+        if (effectiveLow > effectiveHigh)
+        {
+            throw new InvalidOperationException(
+                $"Invalid range for symbol {symbol}: low={effectiveLow}, high={effectiveHigh}");
+        }
+
+        // Update the current range
+        _high = _low + effectiveHigh;
+        _low += effectiveLow;
+
+        // Check for range validity after update
+        if (_low > _high)
+        {
+            throw new InvalidOperationException(
+                $"Invalid range after update: low={_low}, high={_high}");
+        }
+
+        // Store range for debugging
+        _debug.Add((_low, _high));
+
+        // Flush any common prefix bits
+        FlushCommonPrefix();
+
+        // Validate max bit after flushing
+        if (_maxBit < -1)
+        {
+            throw new InvalidOperationException($"Invalid max bit: {_maxBit}");
+        }
+
+        if (_maxBit > 61)
+        {
+            throw new InvalidOperationException($"Max bit too large: {_maxBit}, at risk of overflow");
+        }
+    }
+
+    /// <summary>
+    /// Dispose resources used by the arithmetic coder
+    /// </summary>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            try
             {
-                var bit = (_low >> _maxBit) & 1;
-                _packer.Push((int)bit);
+                Flush();
+            }
+            catch
+            {
+                // Ignore exceptions during disposal
+            }
+
+            _packer.Dispose();
+            _disposed = true;
+        }
+    }
+
+    private static void ValidateParameters(Stream stream, int totalRangeBits)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        if (!stream.CanWrite)
+        {
+            throw new ArgumentException("Stream must be writable", nameof(stream));
+        }
+
+        if (totalRangeBits <= 0)
+        {
+            throw new ArgumentException("Total range bits must be positive", nameof(totalRangeBits));
+        }
+
+        if (totalRangeBits > 30)
+        {
+            throw new ArgumentException("Total range bits must be <= 30 for numerical stability",
+                                       nameof(totalRangeBits));
+        }
+    }
+
+    /// <summary>
+    /// Flush common prefix bits to the stream to maintain numerical precision
+    /// </summary>
+    private void FlushCommonPrefix()
+    {
+        // Validate invariants
+        if (_high < _low)
+        {
+            throw new InvalidOperationException($"Invalid range: low={_low}, high={_high}");
+        }
+
+        if (_maxBit >= 0 && _high >= (1L << (_maxBit + 1)))
+        {
+            throw new InvalidOperationException(
+                $"High value {_high} exceeds maximum bit position {_maxBit}");
+        }
+
+        // While the most significant bits are the same, we can send them to the output
+        while (_maxBit >= 0)
+        {
+            // Get the most significant bit of low and high
+            var b1 = (_low >> _maxBit) & 1;
+            var b2 = (_high >> _maxBit) & 1;
+
+            if (b1 == b2)
+            {
+                // Remove the bit from both low and high
+                _low -= b1 << _maxBit;
+                _high -= b1 << _maxBit;
+
+                // Check invariants after bit removal
+                if (_high < _low)
+                {
+                    throw new InvalidOperationException(
+                        $"Invalid range after bit flush: low={_low}, high={_high}");
+                }
+
+                if (_low < 0)
+                {
+                    throw new InvalidOperationException($"Negative low value: {_low}");
+                }
+
+                // Move to next bit position
                 _maxBit--;
+
+                // Send the common bit to the output
+                _packer.Push((int)b1);
             }
-
-            // Flush the bit packer to ensure all bits are written
-            _packer.Flush();
-        }
-
-        /// <summary>
-        /// Push a symbol to the stream using arithmetic coding
-        /// </summary>
-        /// <param name="symbol">Symbol to encode</param>
-        /// <param name="quantizedCdf">Quantized CDF for the symbol probability distribution</param>
-        /// <exception cref="ArgumentException">Thrown when CDF is invalid</exception>
-        /// <exception cref="InvalidOperationException">Thrown when coding state becomes invalid</exception>
-        public void Push(int symbol, Tensor quantizedCdf)
-        {
-            if (quantizedCdf is null || quantizedCdf.IsInvalid)
+            else
             {
-                throw new ArgumentException("Quantized CDF must be valid", nameof(quantizedCdf));
-            }
-
-            if (symbol < 0 || symbol > quantizedCdf.shape[0] - 1)
-            {
-                throw new ArgumentException(
-                    $"Symbol {symbol} out of range [0, {quantizedCdf.shape[0] - 1}]", nameof(symbol));
-            }
-
-            // Ensure our range is large enough, pushing bits as needed
-            while (Delta < (1L << TotalRangeBits))
-            {
-                _low *= 2;
-                _high = (_high * 2) + 1;
-                _maxBit++;
-            }
-
-            // Get range bounds for the symbol from the CDF
-            long rangeLow = symbol == 0 ? 0 : quantizedCdf[symbol - 1].item<long>();
-            long rangeHigh = quantizedCdf[symbol].item<long>() - 1;
-
-            // Scale the range to the current interval
-            double scale = Delta / (double)(1L << TotalRangeBits);
-            var effectiveLow = (long)Math.Ceiling(rangeLow * scale);
-            var effectiveHigh = (long)Math.Floor(rangeHigh * scale);
-
-            // Check for invalid range
-            if (effectiveLow > effectiveHigh)
-            {
-                throw new InvalidOperationException(
-                    $"Invalid range for symbol {symbol}: low={effectiveLow}, high={effectiveHigh}");
-            }
-
-            // Update the current range
-            _high = _low + effectiveHigh;
-            _low += effectiveLow;
-
-            // Check for range validity after update
-            if (_low > _high)
-            {
-                throw new InvalidOperationException(
-                    $"Invalid range after update: low={_low}, high={_high}");
-            }
-
-            // Store range for debugging
-            _debug.Add((_low, _high));
-
-            // Flush any common prefix bits
-            FlushCommonPrefix();
-
-            // Validate max bit after flushing
-            if (_maxBit < -1)
-            {
-                throw new InvalidOperationException($"Invalid max bit: {_maxBit}");
-            }
-
-            if (_maxBit > 61)
-            {
-                throw new InvalidOperationException($"Max bit too large: {_maxBit}, at risk of overflow");
-            }
-        }
-
-        /// <summary>
-        /// Dispose resources used by the arithmetic coder
-        /// </summary>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposed)
-            {
-                try
-                {
-                    Flush();
-                }
-                catch
-                {
-                    // Ignore exceptions during disposal
-                }
-
-                _packer.Dispose();
-                _disposed = true;
-            }
-        }
-
-        private static void ValidateParameters(Stream stream, int totalRangeBits)
-        {
-            ArgumentNullException.ThrowIfNull(stream);
-
-            if (!stream.CanWrite)
-            {
-                throw new ArgumentException("Stream must be writable", nameof(stream));
-            }
-
-            if (totalRangeBits <= 0)
-            {
-                throw new ArgumentException("Total range bits must be positive", nameof(totalRangeBits));
-            }
-
-            if (totalRangeBits > 30)
-            {
-                throw new ArgumentException("Total range bits must be <= 30 for numerical stability",
-                                           nameof(totalRangeBits));
-            }
-        }
-
-        /// <summary>
-        /// Flush common prefix bits to the stream to maintain numerical precision
-        /// </summary>
-        private void FlushCommonPrefix()
-        {
-            // Validate invariants
-            if (_high < _low)
-            {
-                throw new InvalidOperationException($"Invalid range: low={_low}, high={_high}");
-            }
-
-            if (_maxBit >= 0 && _high >= (1L << (_maxBit + 1)))
-            {
-                throw new InvalidOperationException(
-                    $"High value {_high} exceeds maximum bit position {_maxBit}");
-            }
-
-            // While the most significant bits are the same, we can send them to the output
-            while (_maxBit >= 0)
-            {
-                // Get the most significant bit of low and high
-                var b1 = (_low >> _maxBit) & 1;
-                var b2 = (_high >> _maxBit) & 1;
-
-                if (b1 == b2)
-                {
-                    // Remove the bit from both low and high
-                    _low -= b1 << _maxBit;
-                    _high -= b1 << _maxBit;
-
-                    // Check invariants after bit removal
-                    if (_high < _low)
-                    {
-                        throw new InvalidOperationException(
-                            $"Invalid range after bit flush: low={_low}, high={_high}");
-                    }
-
-                    if (_low < 0)
-                    {
-                        throw new InvalidOperationException($"Negative low value: {_low}");
-                    }
-
-                    // Move to next bit position
-                    _maxBit--;
-
-                    // Send the common bit to the output
-                    _packer.Push((int)b1);
-                }
-                else
-                {
-                    // Bits differ, can't flush any more
-                    break;
-                }
+                // Bits differ, can't flush any more
+                break;
             }
         }
     }

--- a/NeuralCodecs.Torch/Modules/Encodec/BinaryIO.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/BinaryIO.cs
@@ -1,294 +1,293 @@
 using System.Text;
 
-namespace NeuralCodecs.Torch.Modules.Encodec
+namespace NeuralCodecs.Torch.Modules.Encodec;
+
+/// <summary>
+/// Binary I/O utilities for Encodec model files
+/// </summary>
+public static class BinaryIO
 {
-    /// <summary>
-    /// Binary I/O utilities for Encodec model files
-    /// </summary>
-    public static class BinaryIO
+    private const ushort CURRENT_VERSION = 0;
+    private const string MAGIC = "ECDC";
+
+    private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
     {
-        private const ushort CURRENT_VERSION = 0;
-        private const string MAGIC = "ECDC";
+        NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString
+    };
 
-        private static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
-        {
-            NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString
-        };
+    /// <summary>
+    /// Represents supported metadata value types
+    /// </summary>
+    private enum MetadataType : byte
+    {
+        String = 0,
+        Int32 = 1,
+        Boolean = 2,
+        Float = 3,
+        Int64 = 4
+    }
 
-        /// <summary>
-        /// Represents supported metadata value types
-        /// </summary>
-        private enum MetadataType : byte
+    /// <summary>
+    /// Reads an Encodec header with metadata from a stream
+    /// </summary>
+    /// <param name="stream"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="EndOfStreamException"></exception>
+    /// <exception cref="InvalidDataException"></exception>
+    /// <exception cref="IOException"></exception>
+    public static async Task<Dictionary<string, object>> ReadHeaderAsync(Stream stream)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        if (!stream.CanRead)
         {
-            String = 0,
-            Int32 = 1,
-            Boolean = 2,
-            Float = 3,
-            Int64 = 4
+            throw new ArgumentException("Stream must be readable", nameof(stream));
         }
 
-        /// <summary>
-        /// Reads an Encodec header with metadata from a stream
-        /// </summary>
-        /// <param name="stream"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        /// <exception cref="ArgumentException"></exception>
-        /// <exception cref="EndOfStreamException"></exception>
-        /// <exception cref="InvalidDataException"></exception>
-        /// <exception cref="IOException"></exception>
-        public static async Task<Dictionary<string, object>> ReadHeaderAsync(Stream stream)
+        try
         {
-            ArgumentNullException.ThrowIfNull(stream);
-
-            if (!stream.CanRead)
+            // Read and verify magic number
+            var magic = new byte[4];
+            if (await stream.ReadAsync(magic) != 4)
             {
-                throw new ArgumentException("Stream must be readable", nameof(stream));
+                throw new EndOfStreamException("Incomplete header magic number");
             }
 
-            try
+            if (Encoding.ASCII.GetString(magic) != MAGIC)
             {
-                // Read and verify magic number
-                var magic = new byte[4];
-                if (await stream.ReadAsync(magic) != 4)
-                {
-                    throw new EndOfStreamException("Incomplete header magic number");
-                }
-
-                if (Encoding.ASCII.GetString(magic) != MAGIC)
-                {
-                    throw new InvalidDataException("Invalid Encodec header magic number");
-                }
-
-                // Read and verify version
-                int version = stream.ReadByte();
-                if (version != CURRENT_VERSION)
-                {
-                    throw new InvalidDataException($"Unsupported header version: {version}");
-                }
-
-                // Read metadata length
-                var lengthBytes = new byte[4];
-                if (await stream.ReadAsync(lengthBytes) != 4)
-                {
-                    throw new EndOfStreamException("Incomplete metadata length");
-                }
-
-                if (BitConverter.IsLittleEndian)
-                {
-                    Array.Reverse(lengthBytes);
-                }
-
-                var metaLength = BitConverter.ToInt32(lengthBytes);
-
-                // Read metadata JSON
-                var metaBytes = new byte[metaLength];
-                var bytesRead = await stream.ReadAsync(metaBytes);
-                if (bytesRead != metaLength)
-                {
-                    throw new EndOfStreamException("Incomplete metadata");
-                }
-
-                var metaJson = Encoding.UTF8.GetString(metaBytes);
-                return System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(
-                    metaJson, JsonOptions) ?? new Dictionary<string, object>();
+                throw new InvalidDataException("Invalid Encodec header magic number");
             }
-            catch (Exception ex) when (ex is not InvalidDataException)
+
+            // Read and verify version
+            int version = stream.ReadByte();
+            if (version != CURRENT_VERSION)
             {
-                throw new IOException("Failed to read Encodec header", ex);
+                throw new InvalidDataException($"Unsupported header version: {version}");
             }
+
+            // Read metadata length
+            var lengthBytes = new byte[4];
+            if (await stream.ReadAsync(lengthBytes) != 4)
+            {
+                throw new EndOfStreamException("Incomplete metadata length");
+            }
+
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(lengthBytes);
+            }
+
+            var metaLength = BitConverter.ToInt32(lengthBytes);
+
+            // Read metadata JSON
+            var metaBytes = new byte[metaLength];
+            var bytesRead = await stream.ReadAsync(metaBytes);
+            if (bytesRead != metaLength)
+            {
+                throw new EndOfStreamException("Incomplete metadata");
+            }
+
+            var metaJson = Encoding.UTF8.GetString(metaBytes);
+            return System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(
+                metaJson, JsonOptions) ?? new Dictionary<string, object>();
         }
-
-        /// <summary>
-        /// Validates Encodec metadata entries for required keys and types
-        /// </summary>
-        /// <param name="metadata"></param>
-        /// <exception cref="ArgumentNullException"></exception>
-        /// <exception cref="ArgumentException"></exception>
-        public static void ValidateMetadata(Dictionary<string, object> metadata)
+        catch (Exception ex) when (ex is not InvalidDataException)
         {
-            ArgumentNullException.ThrowIfNull(metadata);
+            throw new IOException("Failed to read Encodec header", ex);
+        }
+    }
 
-            var requiredKeys = new[] { "m", "al", "nc", "lm" };
-            foreach (var key in requiredKeys)
-            {
-                if (!metadata.ContainsKey(key))
-                {
-                    throw new ArgumentException($"Missing required metadata key: {key}");
-                }
-            }
+    /// <summary>
+    /// Validates Encodec metadata entries for required keys and types
+    /// </summary>
+    /// <param name="metadata"></param>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentException"></exception>
+    public static void ValidateMetadata(Dictionary<string, object> metadata)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
 
-            // Basic type validation - note that JSON deserialization may give us JsonElement
-            if (metadata["m"] is not string and not System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.String })
+        var requiredKeys = new[] { "m", "al", "nc", "lm" };
+        foreach (var key in requiredKeys)
+        {
+            if (!metadata.ContainsKey(key))
             {
-                throw new ArgumentException("Model name must be string");
-            }
-
-            if (metadata["al"] is not int and not long and not System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.Number })
-            {
-                throw new ArgumentException("Audio length must be integer");
-            }
-
-            if (metadata["nc"] is not int and not System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.Number })
-            {
-                throw new ArgumentException("Number of codebooks must be integer");
-            }
-
-            if (metadata["lm"] is not bool and not System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.True or System.Text.Json.JsonValueKind.False })
-            {
-                throw new ArgumentException("Language model flag must be boolean");
+                throw new ArgumentException($"Missing required metadata key: {key}");
             }
         }
 
-        /// <summary>
-        /// Writes an Encodec header with metadata to a stream
-        /// </summary>
-        /// <param name="stream"></param>
-        /// <param name="metadata"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        /// <exception cref="ArgumentException"></exception>
-        /// <exception cref="IOException"></exception>
-        public static async Task WriteHeaderAsync(Stream stream, Dictionary<string, object> metadata)
+        // Basic type validation - note that JSON deserialization may give us JsonElement
+        if (metadata["m"] is not string and not System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.String })
         {
-            ArgumentNullException.ThrowIfNull(stream);
+            throw new ArgumentException("Model name must be string");
+        }
 
-            if (!stream.CanWrite)
+        if (metadata["al"] is not int and not long and not System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.Number })
+        {
+            throw new ArgumentException("Audio length must be integer");
+        }
+
+        if (metadata["nc"] is not int and not System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.Number })
+        {
+            throw new ArgumentException("Number of codebooks must be integer");
+        }
+
+        if (metadata["lm"] is not bool and not System.Text.Json.JsonElement { ValueKind: System.Text.Json.JsonValueKind.True or System.Text.Json.JsonValueKind.False })
+        {
+            throw new ArgumentException("Language model flag must be boolean");
+        }
+    }
+
+    /// <summary>
+    /// Writes an Encodec header with metadata to a stream
+    /// </summary>
+    /// <param name="stream"></param>
+    /// <param name="metadata"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentException"></exception>
+    /// <exception cref="IOException"></exception>
+    public static async Task WriteHeaderAsync(Stream stream, Dictionary<string, object> metadata)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        if (!stream.CanWrite)
+        {
+            throw new ArgumentException("Stream must be writable", nameof(stream));
+        }
+
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        try
+        {
+            // Serialize metadata to JSON bytes
+            var metaJson = System.Text.Json.JsonSerializer.Serialize(metadata, JsonOptions);
+            var metaBytes = Encoding.UTF8.GetBytes(metaJson);
+
+            // Write header: MAGIC (4 bytes) + VERSION (1 byte) + META_LENGTH (4 bytes)
+            await stream.WriteAsync(Encoding.ASCII.GetBytes(MAGIC));
+            stream.WriteByte((byte)CURRENT_VERSION);
+            var lengthBytes = BitConverter.GetBytes(metaBytes.Length);
+            if (BitConverter.IsLittleEndian)
             {
-                throw new ArgumentException("Stream must be writable", nameof(stream));
+                Array.Reverse(lengthBytes);  // Convert to big-endian
             }
 
-            ArgumentNullException.ThrowIfNull(metadata);
+            await stream.WriteAsync(lengthBytes);
 
-            try
-            {
-                // Serialize metadata to JSON bytes
-                var metaJson = System.Text.Json.JsonSerializer.Serialize(metadata, JsonOptions);
-                var metaBytes = Encoding.UTF8.GetBytes(metaJson);
+            // Write metadata JSON
+            await stream.WriteAsync(metaBytes);
+            await stream.FlushAsync();
+        }
+        catch (Exception ex)
+        {
+            throw new IOException("Failed to write Encodec header", ex);
+        }
+    }
 
-                // Write header: MAGIC (4 bytes) + VERSION (1 byte) + META_LENGTH (4 bytes)
-                await stream.WriteAsync(Encoding.ASCII.GetBytes(MAGIC));
-                stream.WriteByte((byte)CURRENT_VERSION);
-                var lengthBytes = BitConverter.GetBytes(metaBytes.Length);
-                if (BitConverter.IsLittleEndian)
+    private static (string key, object value, int size) ReadMetadataEntry(
+        BinaryReader reader)
+    {
+        // Read key
+        var keyLength = reader.ReadByte();
+        var keyBytes = reader.ReadBytes(keyLength);
+        var key = Encoding.UTF8.GetString(keyBytes);
+
+        // Read type
+        var type = (MetadataType)reader.ReadByte();
+
+        // Read value based on type
+        object value;
+        int valueSize;
+
+        switch (type)
+        {
+            case MetadataType.String:
+                var strLength = reader.ReadUInt16();
+                var strBytes = reader.ReadBytes(strLength);
+                value = Encoding.UTF8.GetString(strBytes);
+                valueSize = strLength;
+                break;
+
+            case MetadataType.Int32:
+                value = reader.ReadInt32();
+                valueSize = 4;
+                break;
+
+            case MetadataType.Int64:
+                value = reader.ReadInt64();
+                valueSize = 8;
+                break;
+
+            case MetadataType.Boolean:
+                value = reader.ReadBoolean();
+                valueSize = 1;
+                break;
+
+            case MetadataType.Float:
+                value = reader.ReadSingle();
+                valueSize = 4;
+                break;
+
+            default:
+                throw new InvalidDataException($"Unknown metadata type: {type}");
+        }
+
+        return (key, value, keyLength + 1 + valueSize); // +1 for type byte
+    }
+
+    private static void WriteMetadataEntry(BinaryWriter writer, string key, object value)
+    {
+        // Write key
+        var keyBytes = Encoding.UTF8.GetBytes(key);
+        if (keyBytes.Length > 255)
+        {
+            throw new ArgumentException($"Key too long: {key}");
+        }
+
+        writer.Write((byte)keyBytes.Length);
+        writer.Write(keyBytes);
+
+        // Write value based on type
+        switch (value)
+        {
+            case string s:
+                writer.Write((byte)MetadataType.String);
+                var strBytes = Encoding.UTF8.GetBytes(s);
+                if (strBytes.Length > 65535)
                 {
-                    Array.Reverse(lengthBytes);  // Convert to big-endian
+                    throw new ArgumentException($"String value too long: {key}");
                 }
 
-                await stream.WriteAsync(lengthBytes);
+                writer.Write((ushort)strBytes.Length);
+                writer.Write(strBytes);
+                break;
 
-                // Write metadata JSON
-                await stream.WriteAsync(metaBytes);
-                await stream.FlushAsync();
-            }
-            catch (Exception ex)
-            {
-                throw new IOException("Failed to write Encodec header", ex);
-            }
-        }
+            case int i:
+                writer.Write((byte)MetadataType.Int32);
+                writer.Write(i);
+                break;
 
-        private static (string key, object value, int size) ReadMetadataEntry(
-            BinaryReader reader)
-        {
-            // Read key
-            var keyLength = reader.ReadByte();
-            var keyBytes = reader.ReadBytes(keyLength);
-            var key = Encoding.UTF8.GetString(keyBytes);
+            case long l:
+                writer.Write((byte)MetadataType.Int64);
+                writer.Write(l);
+                break;
 
-            // Read type
-            var type = (MetadataType)reader.ReadByte();
+            case bool b:
+                writer.Write((byte)MetadataType.Boolean);
+                writer.Write(b);
+                break;
 
-            // Read value based on type
-            object value;
-            int valueSize;
+            case float f:
+                writer.Write((byte)MetadataType.Float);
+                writer.Write(f);
+                break;
 
-            switch (type)
-            {
-                case MetadataType.String:
-                    var strLength = reader.ReadUInt16();
-                    var strBytes = reader.ReadBytes(strLength);
-                    value = Encoding.UTF8.GetString(strBytes);
-                    valueSize = strLength;
-                    break;
-
-                case MetadataType.Int32:
-                    value = reader.ReadInt32();
-                    valueSize = 4;
-                    break;
-
-                case MetadataType.Int64:
-                    value = reader.ReadInt64();
-                    valueSize = 8;
-                    break;
-
-                case MetadataType.Boolean:
-                    value = reader.ReadBoolean();
-                    valueSize = 1;
-                    break;
-
-                case MetadataType.Float:
-                    value = reader.ReadSingle();
-                    valueSize = 4;
-                    break;
-
-                default:
-                    throw new InvalidDataException($"Unknown metadata type: {type}");
-            }
-
-            return (key, value, keyLength + 1 + valueSize); // +1 for type byte
-        }
-
-        private static void WriteMetadataEntry(BinaryWriter writer, string key, object value)
-        {
-            // Write key
-            var keyBytes = Encoding.UTF8.GetBytes(key);
-            if (keyBytes.Length > 255)
-            {
-                throw new ArgumentException($"Key too long: {key}");
-            }
-
-            writer.Write((byte)keyBytes.Length);
-            writer.Write(keyBytes);
-
-            // Write value based on type
-            switch (value)
-            {
-                case string s:
-                    writer.Write((byte)MetadataType.String);
-                    var strBytes = Encoding.UTF8.GetBytes(s);
-                    if (strBytes.Length > 65535)
-                    {
-                        throw new ArgumentException($"String value too long: {key}");
-                    }
-
-                    writer.Write((ushort)strBytes.Length);
-                    writer.Write(strBytes);
-                    break;
-
-                case int i:
-                    writer.Write((byte)MetadataType.Int32);
-                    writer.Write(i);
-                    break;
-
-                case long l:
-                    writer.Write((byte)MetadataType.Int64);
-                    writer.Write(l);
-                    break;
-
-                case bool b:
-                    writer.Write((byte)MetadataType.Boolean);
-                    writer.Write(b);
-                    break;
-
-                case float f:
-                    writer.Write((byte)MetadataType.Float);
-                    writer.Write(f);
-                    break;
-
-                default:
-                    throw new ArgumentException(
-                        $"Unsupported metadata type: {value.GetType()} for key: {key}");
-            }
+            default:
+                throw new ArgumentException(
+                    $"Unsupported metadata type: {value.GetType()} for key: {key}");
         }
     }
 }

--- a/NeuralCodecs.Torch/Modules/Encodec/ConvLayerNorm.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/ConvLayerNorm.cs
@@ -44,6 +44,7 @@ public class ConvLayerNorm : Module<Tensor, Tensor>
         return x.MoveToOuterDisposeScope();
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/Modules/Encodec/EncodecCompressor.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/EncodecCompressor.cs
@@ -1,8 +1,8 @@
-using NeuralCodecs.Torch.Config.Encodec;
 using NeuralCodecs.Core.Utils;
+using NeuralCodecs.Torch.Config.Encodec;
+using NeuralCodecs.Torch.Utils;
 using TorchSharp;
 using static TorchSharp.torch;
-using NeuralCodecs.Torch.Utils;
 
 namespace NeuralCodecs.Torch.Modules.Encodec;
 

--- a/NeuralCodecs.Torch/Modules/Encodec/EncodecLanguageModel.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/EncodecLanguageModel.cs
@@ -1,7 +1,6 @@
 using NeuralCodecs.Core;
 using NeuralCodecs.Core.Configuration;
 using NeuralCodecs.Torch.Config.Encodec;
-using System.Diagnostics;
 using TorchSharp.Modules;
 using TorchSharp.PyBridge;
 using static TorchSharp.torch;
@@ -319,7 +318,6 @@ public class EncodecLanguageModel : Module<Tensor, (Tensor probabilities, List<T
 
         try
         {
-            // Determine file type and load appropriately
             if (path.EndsWith(".th") || path.EndsWith(".pth"))
             {
                 // Load PyTorch format
@@ -330,7 +328,6 @@ public class EncodecLanguageModel : Module<Tensor, (Tensor probabilities, List<T
                 // Default TorchSharp format
                 this.load(path);
             }
-
         }
         catch (Exception ex)
         {
@@ -360,6 +357,7 @@ public class EncodecLanguageModel : Module<Tensor, (Tensor probabilities, List<T
         return (probabilities, newStates, newOffset);
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/Modules/Encodec/EuclideanCodebook.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/EuclideanCodebook.cs
@@ -59,7 +59,10 @@ public class EuclideanCodebook : Module<Tensor, (Tensor quantized, Tensor indice
 
         embed = Parameter(initFn(new long[] { codebookSize, dimension }));
         cluster_size = Parameter(zeros(codebookSize));
-        embed_avg = Parameter(embed.clone());
+        using (no_grad())
+        {
+            embed_avg = Parameter(embed.detach().clone());
+        }
         inited = Parameter(tensor(new[] { !kmeansInit }, dtype: ScalarType.Float32));
 
         RegisterComponents();
@@ -178,6 +181,7 @@ public class EuclideanCodebook : Module<Tensor, (Tensor quantized, Tensor indice
         return distances.argmin(dim: -1).MoveToOuterDisposeScope();
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/Modules/Encodec/NormConv1d.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/NormConv1d.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using TorchSharp.Modules;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
@@ -100,10 +99,7 @@ public class NormConv1d : Module<Tensor, Tensor>
         return convOut.MoveToOuterDisposeScope();
     }
 
-    /// <summary>
-    /// Disposes the managed resources used by the module.
-    /// </summary>
-    /// <param name="disposing">True to dispose managed resources, false otherwise.</param>
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)
@@ -186,7 +182,6 @@ public class NormConv1d : Module<Tensor, Tensor>
         int stride, int padding, long dilation, int groups,
         string norm, bool bias, bool casual)
     {
-        Debug.WriteLine($"Validating NormConv parameters: inchannels: {inChannels}, outchannels: {outChannels}, kernelSize: {kernelSize}, stride: {stride}, padding: {padding}, dilation: {dilation}, groups: {groups}, bias={bias}, casual={casual}, norm: {norm}");
         if (inChannels <= 0)
         {
             throw new ArgumentException($"Input channels must be positive, got {inChannels}");

--- a/NeuralCodecs.Torch/Modules/Encodec/NormConvTranspose1d.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/NormConvTranspose1d.cs
@@ -75,6 +75,7 @@ public class NormConvTranspose1d : Module<Tensor, Tensor>
         return convOut.MoveToOuterDisposeScope();
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)
@@ -100,9 +101,6 @@ public class NormConvTranspose1d : Module<Tensor, Tensor>
             case "layer_norm":
                 return new ConvLayerNorm((int)conv.out_channels, eps);
 
-            //return normParams.TryGetValue("eps", out object? leps) ? LayerNorm(new long[] { conv.out_channels }, (double)leps)
-            //    : LayerNorm(new long[] { conv.out_channels });
-
             case "group_norm":
             case "time_group_norm":
                 if (causal)
@@ -116,13 +114,6 @@ public class NormConvTranspose1d : Module<Tensor, Tensor>
                     throw new ArgumentException("Cannot determine output channels for group norm");
                 }
 
-                //return new TimeGroupNorm(conv.out_channels, eps);
-                //case "group_norm":
-                //    if (causal)
-                //    {
-                //        throw new ArgumentException(
-                //            "GroupNorm doesn't support causal evaluation");
-                //    }
                 return GroupNorm(1, conv.out_channels, eps, affine: true);
 
             case "weight_norm":

--- a/NeuralCodecs.Torch/Modules/Encodec/SConv1d.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/SConv1d.cs
@@ -172,10 +172,7 @@ public class SConv1d : Module<Tensor, Tensor>
         return _normConv.forward(padded).MoveToOuterDisposeScope();
     }
 
-    /// <summary>
-    /// Disposes the managed resources used by the module.
-    /// </summary>
-    /// <param name="disposing">True to dispose managed resources, false otherwise.</param>
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/Modules/Encodec/SConvTranspose1d.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/SConvTranspose1d.cs
@@ -138,10 +138,7 @@ public class SConvTranspose1d : Module<Tensor, Tensor>
         return y.MoveToOuterDisposeScope();
     }
 
-    /// <summary>
-    /// Disposes the managed resources used by the module.
-    /// </summary>
-    /// <param name="disposing">True to dispose managed resources, false otherwise.</param>
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/Modules/Encodec/SEANetDecoder.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/SEANetDecoder.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using TorchSharp.Modules;
 using static NeuralCodecs.Torch.Utils.TorchUtils;
 using static TorchSharp.torch;
@@ -103,7 +102,6 @@ public class SEANetDecoder : Module<Tensor, Tensor>
                 trimRightRatio: trimRightRatio));
 
             // Add residual layers
-            Debug.WriteLine($"SEANetDecoder residual layers: {nResidualLayers}");
             for (int j = 0; j < nResidualLayers; j++)
             {
                 modules.Add(new SEANetResnetBlock(
@@ -154,6 +152,7 @@ public class SEANetDecoder : Module<Tensor, Tensor>
         return layers.forward(x);
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/Modules/Encodec/SEANetEncoder.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/SEANetEncoder.cs
@@ -1,6 +1,3 @@
-using NeuralCodecs.Torch.Utils;
-using System.Collections.Immutable;
-using System.Diagnostics;
 using TorchSharp.Modules;
 using static NeuralCodecs.Torch.Utils.TorchUtils;
 using static TorchSharp.torch;
@@ -13,7 +10,7 @@ namespace NeuralCodecs.Torch.Modules.Encodec;
 /// </summary>
 public class SEANetEncoder : Module<Tensor, Tensor>
 {
-    private int[] _ratios;
+    private readonly int[] _ratios;
     public readonly Sequential layers;
 
     /// <summary>
@@ -65,7 +62,6 @@ public class SEANetEncoder : Module<Tensor, Tensor>
         normParams ??= new Dictionary<string, object>();
 
         ValidateParameters(dimension, nFilters, kernelSize, lastKernelSize, residualKernelSize);
-        Debug.WriteLine($"SEANetEncoder: channels={channels} dimension={dimension} nFilters={nFilters} kernelSize={kernelSize} lastKernelSize={lastKernelSize} residualKernelSize={residualKernelSize}");
 
         var act = GetActivation(activation, activationParams);
         var mult = 1;
@@ -133,8 +129,15 @@ public class SEANetEncoder : Module<Tensor, Tensor>
         RegisterComponents();
     }
 
+    /// <summary>
+    /// Gets the dimension of the intermediate representation.
+    /// </summary>
     public int Dimension { get; }
-    public int TotalRatio => _ratios.Aggregate((a, b) => a * b); // TODO: rename hoplength
+
+    /// <summary>
+    /// Gets the total ratio by multiplying all elements in the ratios array.
+    /// </summary>
+    public int TotalRatio => _ratios.Aggregate((a, b) => a * b);
 
     public override Tensor forward(Tensor x)
     {
@@ -144,6 +147,7 @@ public class SEANetEncoder : Module<Tensor, Tensor>
         return layers.forward(x);
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/Modules/Encodec/SEANetResnetBlock.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/SEANetResnetBlock.cs
@@ -85,6 +85,7 @@ public class SEANetResnetBlock : Module<Tensor, Tensor>
         return add(shortcutOut, blockOut).MoveToOuterDisposeScope();
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/Modules/Encodec/SLSTM.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/SLSTM.cs
@@ -96,6 +96,7 @@ public class SLSTM : Module<Tensor, Tensor>
             (hN.MoveToOuterDisposeScope(), cN.MoveToOuterDisposeScope()));
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/Modules/Encodec/StreamingTransformerEncoder.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/StreamingTransformerEncoder.cs
@@ -125,6 +125,7 @@ public class StreamingTransformerEncoder : Module<Tensor, (Tensor output, List<T
         return (output.MoveToOuterDisposeScope(), newStates, offset + timeSteps);
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/Modules/Encodec/StreamingTransformerEncoderLayer.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/StreamingTransformerEncoderLayer.cs
@@ -110,6 +110,7 @@ public class StreamingTransformerEncoderLayer : Module<Tensor, (Tensor output, T
         return (output.MoveToOuterDisposeScope(), inputForState.MoveToOuterDisposeScope());
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/Modules/Encodec/VectorQuantizer.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/VectorQuantizer.cs
@@ -13,7 +13,7 @@ public class VectorQuantizer : Module<Tensor, (Tensor quantized, Tensor codes, T
     private readonly float _commitmentWeight;
     private readonly float _epsilon;
     private readonly EuclideanCodebook codebook;
-    private readonly Linear projectIn; // TODO rename?
+    private readonly Linear projectIn;
     private readonly Linear projectOut;
 
     public VectorQuantizer(
@@ -114,6 +114,7 @@ public class VectorQuantizer : Module<Tensor, (Tensor quantized, Tensor codes, T
         );
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/Modules/Encodec/WNConv1d.cs
+++ b/NeuralCodecs.Torch/Modules/Encodec/WNConv1d.cs
@@ -126,6 +126,7 @@ public class WNConv1d : Module<Tensor, Tensor>
                                     .MoveToOuterDisposeScope();
     }
 
+    /// <inheritdoc/>
     protected override void Dispose(bool disposing)
     {
         if (disposing)

--- a/NeuralCodecs.Torch/NeuralCodecs.Torch.csproj
+++ b/NeuralCodecs.Torch/NeuralCodecs.Torch.csproj
@@ -10,7 +10,7 @@
 	  <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	  <Title>NeuralCodecs</Title>
 	  <PackageId>NeuralCodecs</PackageId>
-	  <Version>0.3.0</Version>
+	  <Version>0.4.0</Version>
 	  <Authors>Dillion Lowry</Authors>
 	  <Company></Company>
 	  <Description>Neural audio codec implementations in .NET.</Description>
@@ -24,6 +24,7 @@
 	  <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>	  
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+	  <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NeuralCodecs.Torch/NeuralCodecs.cs
+++ b/NeuralCodecs.Torch/NeuralCodecs.cs
@@ -1,61 +1,100 @@
 ﻿using NeuralCodecs.Core.Loading;
 using NeuralCodecs.Torch.Config.DAC;
+using NeuralCodecs.Torch.Config.Dia;
 using NeuralCodecs.Torch.Config.Encodec;
 using NeuralCodecs.Torch.Config.SNAC;
 using NeuralCodecs.Torch.Models;
+using NeuralCodecs.Torch.Modules.Dia;
 
-namespace NeuralCodecs.Torch
+namespace NeuralCodecs.Torch;
+
+/// <summary>
+/// Provides methods for creating and loading neural network models using Torch.
+/// </summary>
+public static partial class NeuralCodecs
 {
     /// <summary>
-    /// Provides methods for creating and loading neural network models using Torch.
+    /// Creates an instance of TorchModelLoader.
     /// </summary>
-    public static partial class NeuralCodecs
+    /// <returns>A new instance of TorchModelLoader.</returns>
+    public static TorchModelLoader CreateTorchLoader()
     {
-        /// <summary>
-        /// Creates an instance of TorchModelLoader.
-        /// </summary>
-        /// <returns>A new instance of TorchModelLoader.</returns>
-        public static TorchModelLoader CreateTorchLoader()
-        {
-            return new TorchModelLoader();
-        }
+        return new TorchModelLoader();
+    }
 
-        /// <summary>
-        /// Asynchronously creates an instance of SNAC using the specified path, configuration, and options.
-        /// </summary>
-        /// <param name="path">The path to the model file.</param>
-        /// <param name="config">The configuration for the SNAC model.</param>
-        /// <param name="options">The options for loading the model.</param>
-        public static async Task<SNAC> CreateSNACAsync(string path, SNACConfig? config = null, ModelLoadOptions? options = null)
-        {
-            var loader = new TorchModelLoader();
-            var model = await loader.LoadModelAsync<SNAC, SNACConfig>(path, config, options);
-            model.eval();
-            return model;
-        }
+    /// <summary>
+    /// Asynchronously creates an instance of the <see cref="SNAC"/> model by loading it from the specified file path.
+    /// </summary>
+    /// <remarks>The returned <see cref="SNAC"/> model is set to evaluation mode after loading. This method is
+    /// designed for scenarios where the model needs to be loaded asynchronously, such as in applications with
+    /// non-blocking I/O requirements.</remarks>
+    /// <param name="path">The file path to the model to be loaded. This cannot be null or empty.</param>
+    /// <param name="config">An optional configuration object of type <see cref="SNACConfig"/> to customize the model's behavior. If null,
+    /// default configuration settings will be used.</param>
+    /// <param name="options">Optional model loading options of type <see cref="ModelLoadOptions"/> to control how the model is loaded. If
+    /// null, default options will be applied.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the loaded <see cref="SNAC"/> model
+    /// instance.</returns>
+    public static async Task<SNAC> CreateSNACAsync(string path, SNACConfig? config = null, ModelLoadOptions? options = null)
+    {
+        var loader = new TorchModelLoader();
+        var model = await loader.LoadModelAsync<SNAC, SNACConfig>(path, config, options);
+        model.eval();
+        return model;
+    }
 
-        /// <summary>
-        /// Asynchronously creates an instance of DAC using the specified path, configuration, and options.
-        /// </summary>
-        /// <param name="path">The path to the model file.</param>
-        /// <param name="config">The configuration for the DAC model.</param>
-        /// <param name="options">The options for loading the model.</param>
-        /// <returns>A new instance of DAC.</returns>
-        public static async Task<DAC> CreateDACAsync(string path, DACConfig? config = null, ModelLoadOptions? options = null)
-        {
-            var loader = new TorchModelLoader();
-            options ??= new ModelLoadOptions() { HasConfigFile = false, ValidateModel = false };
-            var model = await loader.LoadModelAsync<DAC, DACConfig>(path, config, options);
-            model.eval();
-            return model;
-        }
-        public static async Task<Encodec> CreateEncodecAsync(string path, EncodecConfig? config = null, ModelLoadOptions? options = null)
-        {
-            var loader = new TorchModelLoader();
-            var model = await loader.LoadModelAsync<Encodec, EncodecConfig>(path, config, options);
-            model.eval();
-            return model;
-        }
+    /// <summary>
+    /// Asynchronously creates a new instance of the <see cref="DAC"/> model by loading it from the specified file path.
+    /// </summary>
+    /// <remarks>The method uses a <see cref="TorchModelLoader"/> to load the model and sets it to evaluation
+    /// mode after loading.</remarks>
+    /// <param name="path">The file path to the model to be loaded. This cannot be null or empty.</param>
+    /// <param name="config">An optional configuration object of type <see cref="DACConfig"/> to customize the model loading process. If
+    /// null, default configuration settings will be used.</param>
+    /// <param name="options">Optional model loading options of type <see cref="ModelLoadOptions"/>. If null, default options will be applied.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the loaded <see cref="DAC"/> model.</returns>
+    public static async Task<DAC> CreateDACAsync(string path, DACConfig? config = null, ModelLoadOptions? options = null)
+    {
+        var loader = new TorchModelLoader();
+        options ??= new ModelLoadOptions() { HasConfigFile = false, ValidateModel = false };
+        var model = await loader.LoadModelAsync<DAC, DACConfig>(path, config, options);
+        model.eval();
+        return model;
+    }
+    /// <summary>
+    /// Asynchronously creates an instance of the <see cref="Encodec"/> model using the specified file path and optional
+    /// configuration.
+    /// </summary>
+    /// <param name="path">The file path to the model file. This cannot be null or empty.</param>
+    /// <param name="config">An optional <see cref="EncodecConfig"/> object to configure the model. If null, default configuration is used.</param>
+    /// <param name="options">Optional <see cref="ModelLoadOptions"/> to customize the model loading process. If null, default options are
+    /// applied.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the initialized <see
+    /// cref="Encodec"/> model.</returns>
+    public static async Task<Encodec> CreateEncodecAsync(string path, EncodecConfig? config = null, ModelLoadOptions? options = null)
+    {
+        var loader = new TorchModelLoader();
+        var model = await loader.LoadModelAsync<Encodec, EncodecConfig>(path, config, options);
+        model.eval();
+        return model;
+    }
 
+    /// <summary>
+    /// Asynchronously creates a new instance of the <see cref="Dia"/> model from the specified file path.
+    /// </summary>
+    /// <remarks>The method uses a <see cref="TorchModelLoader"/> to load the model asynchronously. The model
+    /// is returned in evaluation mode, ready for inference.</remarks>
+    /// <param name="path">The file path to the model file to be loaded. This cannot be null or empty.</param>
+    /// <param name="config">An optional configuration object of type <see cref="DiaConfig"/> to customize the model loading process. If
+    /// null, default configuration settings will be used.</param>
+    /// <param name="options">Optional model loading options of type <see cref="ModelLoadOptions"/>. If null, default options will be applied.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the loaded <see cref="Dia"/> model.</returns>
+    public static async Task<Dia> CreateDiaAsync(string path, DiaConfig? config = null, ModelLoadOptions? options = null)
+    {
+        var loader = new TorchModelLoader();
+        options ??= new ModelLoadOptions() { HasConfigFile = false, ValidateModel = false };
+        var model = await loader.LoadModelAsync<Dia, DiaConfig>(path, config, options);
+        model.eval();
+        return model;
     }
 }

--- a/NeuralCodecs.Torch/Utils/AttentionUtils.cs
+++ b/NeuralCodecs.Torch/Utils/AttentionUtils.cs
@@ -1,0 +1,187 @@
+using static TorchSharp.torch;
+using static TorchSharp.torch.nn;
+
+namespace NeuralCodecs.Torch.Utils;
+
+/// <summary>
+/// General-purpose attention utilities for various attention mechanisms.
+/// </summary>
+public static class AttentionUtils
+{    
+    /// <summary>
+    /// Computes scaled dot-product attention matching PyTorch's API.
+    /// </summary>
+    /// <param name="query">Query tensor [batch_size, num_heads, query_length, head_dim].</param>
+    /// <param name="key">Key tensor [batch_size, num_heads, key_length, head_dim] or [batch_size, num_kv_heads, key_length, head_dim] for GQA.</param>
+    /// <param name="value">Value tensor [batch_size, num_heads, key_length, head_dim] or [batch_size, num_kv_heads, key_length, head_dim] for GQA.</param>
+    /// <param name="attentionMask">Optional attention mask. False values are masked out.</param>
+    /// <param name="dropoutRate">Dropout probability for attention weights (0.0 = no dropout).</param>
+    /// <param name="isCausal">Whether to apply causal masking (lower triangular mask).</param>
+    /// <param name="scale">Scaling factor. If null, uses 1/sqrt(head_dim).</param>
+    /// <param name="enableGqa">Whether to enable Grouped Query Attention (repeats key/value to match query heads).</param>
+    /// <param name="gqaGroups">Number of repetitions for GQA. If null, computed automatically from head dimensions.</param>
+    /// <returns>Attention output tensor [batch_size, num_heads, query_length, head_dim].</returns>
+    public static Tensor ScaledDotProductAttention(
+        Tensor query,
+        Tensor key,
+        Tensor value,
+        Tensor? attentionMask = null,
+        float dropoutRate = 0.0f,
+        bool isCausal = false,
+        float? scale = null,
+        bool enableGqa = false,
+        int? gqaGroups = null)
+    {
+        long headDim = query.shape[3];
+        float actualScale = scale ?? (1.0f / MathF.Sqrt(headDim));
+
+        if (enableGqa)
+        {
+            key = key.repeat_interleave(gqaGroups ?? (query.shape[1] / key.shape[1]), dim: 1);
+            value = value.repeat_interleave(gqaGroups ?? (query.shape[1] / value.shape[1]), dim: 1);
+        }
+
+        // Compute attention scores
+        var scores = matmul(query, key.transpose(-1, -2)) * actualScale;
+
+        // Apply causal mask if needed
+        if (isCausal)
+        {
+            long queryLen = query.shape[2];
+            long keyLen = key.shape[2];
+            var causalMask = tril(ones(queryLen, keyLen, dtype: ScalarType.Bool, device: query.device));
+            scores.masked_fill_(~causalMask, float.NegativeInfinity);
+        }
+
+        // Apply attention mask if provided
+        if (attentionMask is not null)
+        {
+            scores.masked_fill_(~attentionMask, float.NegativeInfinity);
+        }
+
+
+        // Apply softmax to get attention weights
+        var attentionWeights = functional.softmax(scores, dim: -1);
+
+        // Apply dropout if specified
+        if (dropoutRate > 0.0f)
+        {
+            attentionWeights = functional.dropout(attentionWeights, p: dropoutRate, training: true);
+        }
+
+        // Compute output
+        return matmul(attentionWeights, value);
+    }
+
+    /// <summary>
+    /// Creates a simple causal attention mask.
+    /// </summary>
+    /// <param name="sequenceLength">Length of the sequence.</param>
+    /// <param name="device">Device to create the mask on.</param>
+    /// <param name="dtype">Data type for the mask.</param>
+    /// <returns>Causal mask tensor [sequence_length, sequence_length].</returns>
+    public static Tensor CreateCausalMask(long sequenceLength, Device device, ScalarType dtype = ScalarType.Bool)
+    {
+        return tril(ones(sequenceLength, sequenceLength, dtype: dtype, device: device));
+    }
+
+    /// <summary>
+    /// Creates a combined attention mask from padding and optional causal masking.
+    /// </summary>
+    /// <param name="queryPaddingMask">Query padding mask [batch_size, query_length].</param>
+    /// <param name="keyPaddingMask">Key padding mask [batch_size, key_length].</param>
+    /// <param name="isCausal">Whether to apply causal masking.</param>
+    /// <param name="device">Device to create the mask on.</param>
+    /// <returns>Combined attention mask [batch_size, 1, query_length, key_length].</returns>
+    public static Tensor CreateCombinedMask(
+        Tensor queryPaddingMask,
+        Tensor keyPaddingMask,
+        bool isCausal,
+        Device device)
+    {
+        using var scope = NewDisposeScope();
+
+        // Reshape masks for broadcasting
+        var queryMask = queryPaddingMask.unsqueeze(2);  // [B, T_q, 1]
+        var keyMask = keyPaddingMask.unsqueeze(1);      // [B, 1, T_k]
+
+        // Create base mask where both query and key positions are valid
+        var mask = queryMask.logical_and(keyMask);      // [B, T_q, T_k]
+
+        if (isCausal)
+        {
+            long queryLen = queryMask.shape[1];
+            long keyLen = keyMask.shape[2];
+            var causalMask = CreateCausalMask(Math.Max(queryLen, keyLen), device)
+                .narrow(0, 0, queryLen)
+                .narrow(1, 0, keyLen);
+            mask = mask.logical_and(causalMask);
+        }
+
+        return mask.unsqueeze(1).MoveToOuterDisposeScope(); // [B, 1, T_q, T_k]
+    }
+
+    /// <summary>
+    /// Applies rotary positional embeddings to query and key tensors.
+    /// </summary>
+    /// <param name="tensor">Input tensor [batch_size, num_heads, seq_length, head_dim].</param>
+    /// <param name="cos">Cosine values for rotary embeddings.</param>
+    /// <param name="sin">Sine values for rotary embeddings.</param>
+    /// <returns>Tensor with rotary embeddings applied.</returns>
+    public static Tensor ApplyRotaryEmbedding(Tensor tensor, Tensor cos, Tensor sin)
+    {
+        // Split the last dimension into two halves
+        long headDim = tensor.shape[3];
+        long halfDim = headDim / 2;
+        var x1 = tensor.narrow(-1, 0, halfDim);
+        var x2 = tensor.narrow(-1, halfDim, halfDim);
+
+        // Apply rotary transformation: (x1 * cos - x2 * sin, x1 * sin + x2 * cos)
+        var rotatedX1 = (x1 * cos) - (x2 * sin);
+        var rotatedX2 = (x1 * sin) + (x2 * cos);
+
+        return cat(new[] { rotatedX1, rotatedX2 }, dim: -1);
+    }
+
+    /// <summary>
+    /// Computes multi-head self-attention with flexible options.
+    /// </summary>
+    /// <param name="input">Input tensor [batch_size, seq_length, embed_dim].</param>
+    /// <param name="queryProj">Query projection layer.</param>
+    /// <param name="keyProj">Key projection layer.</param>
+    /// <param name="valueProj">Value projection layer.</param>
+    /// <param name="outputProj">Output projection layer.</param>
+    /// <param name="numHeads">Number of attention heads.</param>
+    /// <param name="attentionMask">Optional attention mask.</param>
+    /// <param name="isCausal">Whether to apply causal masking.</param>
+    /// <param name="dropoutRate">Dropout rate for attention weights.</param>
+    /// <returns>Output tensor [batch_size, seq_length, embed_dim].</returns>
+    public static Tensor MultiHeadSelfAttention(
+        Tensor input,
+        Module<Tensor, Tensor> queryProj,
+        Module<Tensor, Tensor> keyProj,
+        Module<Tensor, Tensor> valueProj,
+        Module<Tensor, Tensor> outputProj,
+        int numHeads,
+        Tensor? attentionMask = null,
+        bool isCausal = false,
+        float dropoutRate = 0.0f)
+    {
+        long batchSize = input.shape[0];
+        long seqLength = input.shape[1];
+        long embedDim = input.shape[2];
+        long headDim = embedDim / numHeads;
+
+        // Project to Q, K, V
+        var query = queryProj.forward(input).view(batchSize, seqLength, numHeads, headDim).transpose(1, 2);
+        var key = keyProj.forward(input).view(batchSize, seqLength, numHeads, headDim).transpose(1, 2);
+        var value = valueProj.forward(input).view(batchSize, seqLength, numHeads, headDim).transpose(1, 2);
+
+        // Apply attention
+        var attnOutput = ScaledDotProductAttention(query, key, value, attentionMask, dropoutRate, isCausal);
+
+        // Reshape and project output
+        attnOutput = attnOutput.transpose(1, 2).contiguous().view(batchSize, seqLength, embedDim);
+        return outputProj.forward(attnOutput);
+    }
+}

--- a/NeuralCodecs.Torch/Utils/TensorExtensions.cs
+++ b/NeuralCodecs.Torch/Utils/TensorExtensions.cs
@@ -1,5 +1,4 @@
-﻿using TorchSharp;
-using static TorchSharp.torch;
+﻿using static TorchSharp.torch;
 
 namespace NeuralCodecs.Torch.Utils;
 
@@ -36,7 +35,7 @@ public static class TensorExtensions
         }
 
         var n = tensor.size(dim);
-        shift = (int)((shift % n + n) % n); // Handle negative shifts
+        shift = (int)(((shift % n) + n) % n); // Handle negative shifts
 
         // Store the wrapped portion
         using var temp = tensor.narrow(dim, n - shift, shift).clone();
@@ -56,6 +55,37 @@ public static class TensorExtensions
     public static float[] ToFloatArray(this Tensor tensor)
     {
         return tensor.cpu().detach().to(float32).data<float>().ToArray();
+    }
+
+    /// <summary>
+    /// Creates a proper boolean mask from a condition
+    /// </summary>
+    public static Tensor ToMask(this Tensor condition)
+    {
+        return condition.to_type(ScalarType.Bool);
+    }
+
+    /// <summary>
+    /// Checks if the tensor is null or invalid.
+    /// </summary>
+    /// <param name="tensor"></param>
+    /// <returns>True if the tensor is null or invalid, false otherwise</returns>
+    public static bool IsNull(this Tensor tensor)
+    {
+        return tensor is null || tensor.IsInvalid;
+    }
+
+    /// <summary>
+    /// Determines whether the specified <see cref="Tensor"/> instance is not null and is valid.
+    /// </summary>
+    /// <remarks>A <see cref="Tensor"/> is considered valid if it is not <see langword="null"/> and its <see
+    /// cref="Tensor.IsInvalid"/> property is <see langword="false"/>.</remarks>
+    /// <param name="tensor">The <see cref="Tensor"/> instance to check.</param>
+    /// <returns><see langword="true"/> if the <paramref name="tensor"/> is not <see langword="null"/> and is valid; otherwise,
+    /// <see langword="false"/>.</returns>
+    public static bool IsNotNull(this Tensor tensor)
+    {
+        return tensor is not null && !tensor.IsInvalid;
     }
 
     public static void WriteTensorToFile(this Tensor tensor, string filePath, int precision = 30, bool append = false, int? count = 200)

--- a/NeuralCodecs.Torch/Utils/TensorUtils.cs
+++ b/NeuralCodecs.Torch/Utils/TensorUtils.cs
@@ -58,6 +58,17 @@ public static class TensorUtils
     }
 
     /// <summary>
+    /// Logs tensor shape information to the console and writes tensor data to a file.
+    /// </summary>
+    /// <param name="tensor">The tensor to log.</param>
+    /// <param name="name">Name identifier for the tensor in logs and filename.</param>
+    public static void LogTensor(Tensor tensor, string name, int precision = 10, int count = 1500)
+    {
+        Console.WriteLine($"{name} shape: {string.Join(", ", tensor.shape)}");
+        tensor.WriteTensorToFile($"{name}.txt", precision, count: count);
+    }
+
+    /// <summary>
     /// Performs padding for 1D tensors with special handling for reflection padding
     /// </summary>
     /// <param name="x">Input tensor</param>

--- a/NeuralCodecs.Torch/Utils/TorchUtils.cs
+++ b/NeuralCodecs.Torch/Utils/TorchUtils.cs
@@ -1,4 +1,5 @@
 ﻿using NeuralCodecs.Core.Configuration;
+using TorchSharp;
 using static TorchSharp.torch;
 using static TorchSharp.torch.nn;
 using DeviceType = NeuralCodecs.Core.Configuration.DeviceType;
@@ -46,6 +47,41 @@ public static class TorchUtils
     }
 
     /// <summary>
+    /// Performs interpolation on tensors.
+    /// </summary>
+    /// <param name="x">Input tensor for interpolation points</param>
+    /// <param name="xp">Known data points</param>
+    /// <param name="fp">Function values at known data points</param>
+    /// <param name="dim">Dimension along which to interpolate</param>
+    /// <param name="linear">Whether to use linear interpolation</param>
+    /// <returns>Interpolated values</returns>
+    public static Tensor Interp(Tensor x, Tensor xp, Tensor fp, long dim = -1, bool linear = true)
+    {
+        using var scope = torch.NewDisposeScope();
+        // Move the interpolation dimension to the last axis
+        x = x.movedim([dim], [-1]);
+        xp = xp.movedim([dim], [-1]);
+        fp = fp.movedim([dim], [-1]);
+        var offset = torch.diff(fp) / torch.diff(xp);
+        var slope = fp[TensorIndex.Ellipsis, ..^1] - (offset * xp[TensorIndex.Ellipsis, ..^1]);
+        var indices = torch.searchsorted(xp, x, right: false);
+
+        if (linear)
+        {
+            indices = torch.clamp(indices - 1, 0, offset.shape[^1] - 1);
+        }
+        else // constant
+        {
+            // Pad m and b to get constant values outside of xp range
+            offset = torch.cat([torch.zeros_like(offset)[TensorIndex.Ellipsis, ..1], offset, torch.zeros_like(offset)[TensorIndex.Ellipsis, ..1]], dim: -1);
+            slope = torch.cat([fp[TensorIndex.Ellipsis, ..1], slope, fp[TensorIndex.Ellipsis, ^1..]], dim: -1);
+        }
+
+        var values = (offset.gather(-1, indices) * x) + slope.gather(-1, indices);
+        return values.movedim([-1], [dim]).MoveToOuterDisposeScope();
+    }
+
+    /// <summary>
     /// Gets the torch device based on the provided device configuration.
     /// </summary>
     /// <param name="device">The device configuration.</param>
@@ -58,11 +94,11 @@ public static class TorchUtils
         {
             DeviceType.CPU => CPU,
 
-            DeviceType.CUDA when cuda.is_available() => CUDA,
+            DeviceType.CUDA when cuda.is_available() => new Device("CUDA", device.Index),
 
             DeviceType.CUDA => throw new InvalidOperationException("CUDA requested but not available"),
 
             _ => CPU
         };
-    }
+    }
 }

--- a/NeuralCodecs.sln
+++ b/NeuralCodecs.sln
@@ -12,7 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE.txt = LICENSE.txt
 		nc_logo.png = nc_logo.png
 		README.md = README.md
-		THIRD-PARTY-NOTICES.TXT = THIRD-PARTY-NOTICES.TXT
+		THIRD-PARTY-NOTICES.md = THIRD-PARTY-NOTICES.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NeuralCodecs.Torch.Examples", "NeuralCodecs.Torch.Examples\NeuralCodecs.Torch.Examples.csproj", "{BE93E11F-D3AA-45DA-928A-A24393688D15}"
@@ -20,21 +20,35 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{33D413AE-C258-497F-8058-EE5AD936C450}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{33D413AE-C258-497F-8058-EE5AD936C450}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33D413AE-C258-497F-8058-EE5AD936C450}.Debug|x64.ActiveCfg = Debug|x64
+		{33D413AE-C258-497F-8058-EE5AD936C450}.Debug|x64.Build.0 = Debug|x64
 		{33D413AE-C258-497F-8058-EE5AD936C450}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33D413AE-C258-497F-8058-EE5AD936C450}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33D413AE-C258-497F-8058-EE5AD936C450}.Release|x64.ActiveCfg = Release|x64
+		{33D413AE-C258-497F-8058-EE5AD936C450}.Release|x64.Build.0 = Release|x64
 		{3549FA01-CD21-4465-8816-A2BEAAE391D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3549FA01-CD21-4465-8816-A2BEAAE391D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3549FA01-CD21-4465-8816-A2BEAAE391D7}.Debug|x64.ActiveCfg = Debug|x64
+		{3549FA01-CD21-4465-8816-A2BEAAE391D7}.Debug|x64.Build.0 = Debug|x64
 		{3549FA01-CD21-4465-8816-A2BEAAE391D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3549FA01-CD21-4465-8816-A2BEAAE391D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3549FA01-CD21-4465-8816-A2BEAAE391D7}.Release|x64.ActiveCfg = Release|x64
+		{3549FA01-CD21-4465-8816-A2BEAAE391D7}.Release|x64.Build.0 = Release|x64
 		{BE93E11F-D3AA-45DA-928A-A24393688D15}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BE93E11F-D3AA-45DA-928A-A24393688D15}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE93E11F-D3AA-45DA-928A-A24393688D15}.Debug|x64.ActiveCfg = Debug|x64
+		{BE93E11F-D3AA-45DA-928A-A24393688D15}.Debug|x64.Build.0 = Debug|x64
 		{BE93E11F-D3AA-45DA-928A-A24393688D15}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE93E11F-D3AA-45DA-928A-A24393688D15}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE93E11F-D3AA-45DA-928A-A24393688D15}.Release|x64.ActiveCfg = Release|x64
+		{BE93E11F-D3AA-45DA-928A-A24393688D15}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="https://github.com/DillionLowry/NeuralCodecs/blob/main/nc_logo.png" width="50" height="50">  NeuralCodecs [![NuGet Version](https://img.shields.io/nuget/v/NeuralCodecs?style=flat)](https://www.nuget.org/packages/NeuralCodecs)
 
-NeuralCodecs is a .NET library for neural audio codec implementations, designed for efficient audio compression and reconstruction.
+NeuralCodecs is a .NET library for neural audio codec implementations and TTS models written purely in C#. It includes implementations of SNAC, DAC, Encodec, and Dia, along with advanced audio processing tools.
 
 ## Features
 - **SNAC**: [Multi-**S**cale **N**eural **A**udio **C**odec](https://github.com/hubertsiuzdak/snac)
@@ -16,6 +16,13 @@ NeuralCodecs is a .NET library for neural audio codec implementations, designed 
   - Variable bitrate compression (1.5-24 kbps)
   - Neural language model for enhanced compression quality
   - Direct file compression to .ecdc format
+- **Dia**: [Nari Labs' Dia text-to-speech model](https://github.com/nari-labs/dia)
+  - 1.6B parameter text-to-speech model for highly realistic dialogue generation
+  - Direct transcript-to-speech generation with emotion and tone control
+  - Audio-conditioned generation for voice cloning and style transfer
+  - Support for non-verbal communications (laughter, coughing, throat clearing, etc.)
+  - Speaker-aware dialogue generation with [S1] and [S2] tags
+  - Custom dynamic speed control to handle Dia's issue with automatic speed-up on long inputs
 - **AudioTools**: Advanced audio processing utilities
   - Based on Descript's [audiotools](https://github.com/descriptinc/audiotools) Python package
   - Extended with .NET-specific optimizations and additional features
@@ -28,6 +35,50 @@ NeuralCodecs is a .NET library for neural audio codec implementations, designed 
 - TorchSharp or libTorch compatible with your platform
 - NAudio (for audio processing)
 - SkiaSharp (for visualization features)
+
+## Installation  
+Install the main package from NuGet:  
+```bash
+dotnet add package NeuralCodecs
+```
+
+Or the Package Manager Console:  
+```powershell
+Install-Package NeuralCodecs
+```
+
+## Model Downloads
+
+Models will be automatically downloaded given the huggingface user/model, or can be downloaded separately:
+
+**SNAC Models** - Available from [hubersiuzdak's HuggingFace](https://huggingface.co/hubertsiuzdak)
+
+**DAC Models** - Available from [Descript's HuggingFace](https://https://huggingface.co/descript)
+
+**Encodec Models** - Available from [Meta's HuggingFace](https://huggingface.co/facebook)
+
+**Dia Model** - Available from [Nari Labs' HuggingFace](https://https://huggingface.co/nari-labs/Dia-1.6B)
+- *Requires both Dia model weights and DAC codec for full audio generation*
+
+## Quick Start
+
+Here's a simple example to get you started:
+
+```csharp
+using NeuralCodecs;
+
+// Load a SNAC model
+var model = await NeuralCodecs.CreateSNACAsync("path/to/model.pt");
+
+// Process audio
+float[] audioData = LoadAudioFile("input.wav");
+var compressed = model.ProcessAudio(audioData, sampleRate: 24000);
+
+// Save the result
+SaveAudioFile("output.wav", compressed);
+```
+
+For more detailed examples, see the examples section below.
 
 ## Usage
 
@@ -151,6 +202,133 @@ var (decompressedAudio, sampleRate) = await EncodecCompressor.DecompressFromFile
 
 ```
 
+### Dia Text-to-Speech Features
+
+Dia is a 1.6B parameter text-to-speech model that generates highly realistic dialogue directly from transcripts:
+
+```csharp
+// Load Dia model with optional DAC codec
+var diaConfig = new DiaConfig 
+{ 
+    LoadDACModel = true,
+    SampleRate = 44100 
+};
+var diaModel = NeuralCodecs.CreateDiaAsync("model.pt", diaconfig)
+
+// or use LoadDACModel = false in config and manually load DAC:
+diaModel.LoadDacModel("dac_model.pt");
+
+// Basic text-to-speech generation
+var text = "[S1] Hello, how are you today? [S2] I'm doing great, thanks for asking!";
+var audioOutput = diaModel.Generate(
+    text: text,
+    maxTokens: 1000,
+    cfgScale: 3.0f,
+    temperature: 1.2f,
+    topP: 0.95f);
+
+// Voice cloning with audio prompt
+var audioPromptPath = "reference_voice.wav";
+var clonedAudio = diaModel.Generate(
+    text: "[S1] This is my cloned voice speaking new words.",
+    audioPromptPath: audioPromptPath,
+    maxTokens: 1000);
+
+// Batch generation for multiple texts
+var texts = new List<string>
+{
+    "[S1] First dialogue line.",
+    "[S2] Second dialogue line with (laughs) non-verbal."
+};
+var batchResults = diaModel.Generate(texts, maxTokens: 800);
+
+// Save generated audio
+Dia.SaveAudio("output.wav", audioOutput);
+```
+
+#### Advanced Dia Configuration
+
+**Audio Speed Correction:**
+Dia includes built-in speed correction to handle the automatic speed-up issue on longer inputs:
+
+```csharp
+var diaConfig = new DiaConfig 
+{ 
+    LoadDACModel = true,
+    SampleRate = 44100,
+    // Configure speed correction method
+    SpeedCorrectionMethod = AudioSpeedCorrectionMethod.Hybrid, // Default: best quality
+    // Configure slowdown mode
+    SlowdownMode = AudioSlowdownMode.Dynamic // Default: adapts to text length
+};
+```
+
+#### Available speed correction methods:
+- **None**: No speed correction applied
+- **TorchSharp**: TorchSharp-based linear interpolation
+- **Hybrid**: Combines TorchSharp and NAudio methods (recommended)
+- **NAudioResampling**: Uses NAudio resampling for speed correction
+- **All**: Creates separate outputs using all methods (for testing/comparison)
+
+#### Available slowdown modes:
+- **Static**: Uses a fixed slowdown factor
+- **Dynamic**: Adjusts slowdown based on text length (recommended)
+
+
+**Speed Correction Examples:**
+```csharp
+// For highest quality output (default)
+var highQualityConfig = new DiaConfig 
+{ 
+    SpeedCorrectionMethod = AudioSpeedCorrectionMethod.Hybrid,
+    SlowdownMode = AudioSlowdownMode.Dynamic
+};
+
+// For testing multiple correction methods
+var testConfig = new DiaConfig 
+{ 
+    SpeedCorrectionMethod = AudioSpeedCorrectionMethod.All // Generates multiple output variants
+};
+
+// For no speed correction (fastest processing)
+var fastConfig = new DiaConfig 
+{ 
+    SpeedCorrectionMethod = AudioSpeedCorrectionMethod.None
+};
+```
+
+#### Dia Generation Guidelines
+
+**Memory Usage:** Similar to the python implementation, ~10-11GB GPU memory is required for the Dia model with DAC codec.
+
+**Text Format Requirements:**
+- Always begin input text with `[S1]` speaker tag
+- Alternate between `[S1]` and `[S2]` for dialogue (repeating the same speaker tag consecutively may impact generation)
+- Keep input text moderate length (10-20 seconds of corresponding audio)
+
+**Non-Verbal Communications:**
+Dia supports various non-verbal tags. Some work more consistently than others (laughs, chuckles), but be prepared for occasional unexpected output from some tags (sneezes, applause, coughs ...) 
+```csharp
+var textWithNonVerbals = "[S1] I can't believe it! (gasps) [S2] That's amazing! (laughs)";
+```
+
+Supported non-verbals: `(laughs)`, `(clears throat)`, `(sighs)`, `(gasps)`, `(coughs)`, `(singing)`, `(sings)`, `(mumbles)`, `(beep)`, `(groans)`, `(sniffs)`, `(claps)`, `(screams)`, `(inhales)`, `(exhales)`, `(applause)`, `(burps)`, `(humming)`, `(sneezes)`, `(chuckle)`, `(whistles)`
+
+**Voice Cloning Best Practices:**
+- Provide 5-10 seconds of reference audio for optimal results
+- Include the transcript of the reference audio before your generation text
+- Use correct speaker tags in the reference transcript
+- Approximately 1 second  per 86 tokens for duration estimation
+
+```csharp
+// Voice cloning example with transcript
+var referenceTranscript = "[S1] This is the reference voice speaking clearly.";
+var newText = "[S1] Now I will say something completely different.";
+var clonedOutput = diaModel.Generate(
+    text: referenceTranscript + " " + newText,
+    audioPromptPath: "reference.wav");
+```
+
 ## Example
 
 Check out the Example project for a complete implementation, including:
@@ -161,16 +339,26 @@ Check out the Example project for a complete implementation, including:
 
 The example includes tools for visualizing and comparing audio spectrograms:
 
-DAC Codec 24kHz before and after compression
+*Audio before and after compression with DAC Codec 24kHz*  
 <img src="Docs/Images/spectrogram_DAC_24k.png" width="500" height="300">
 
 ## Acknowledgments
-- [SNAC](https://github.com/hubertsiuzdak/snac) - Original SNAC implementation
-- [Descript Audio Codec](https://github.com/descriptinc/descript-audio-codec) - DAC reference
-- [Encodec](https://github.com/facebookresearch/encodec) - Meta's neural audio codec
+- [SNAC](https://github.com/hubertsiuzdak/snac) - hubertsiuzdak's original python implementation
+- [Descript Audio Codec](https://github.com/descriptinc/descript-audio-codec) - Descript's original python implementation
+- [Encodec](https://github.com/facebookresearch/encodec) - Meta's original python implementation
+- [Dia](https://github.com/nari-labs/dia) - Nari Labs' original python implementation
 
 ## Contributing
-Suggestions and contributions are welcome! Feel free to submit a pull request.
+
+Suggestions and contributions are welcome! Here's how you can help:
+
+### Ways to Contribute
+- **Bug Reports**: Submit issues with reproduction steps
+- **Feature Requests**: Propose new codec implementations or features
+- **Code Contributions**: Submit pull requests with improvements
+- **Documentation**: Help improve examples and documentation
+- **Testing**: Test with different models and platforms
 
 ## License
-This project is licensed under the MIT License.
+This project is licensed under the Apache-2.0 License, see the LICENSE file for more information.  
+This project uses libraries under several different licenses, see THIRD-PARTY-NOTICES for more information.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,4 +1,14 @@
-﻿
+﻿License notice for Dia
+------------------------------------
+
+https://github.com/nari-labs/dia
+
+Copyright (c) 2025 Nari Labs
+
+Licensed under Apache-2.0
+
+Available at https://www.apache.org/licenses/LICENSE-2.0
+
 License notice for EnCodec
 ------------------------------------
 


### PR DESCRIPTION
### Dia Text-to-Speech Model Support
- **Full integration** of Nari Labs' Dia 1.6B parameter TTS model
- **Speaker-aware dialogue** generation with `[S1]`/`[S2]` tags
- **Voice cloning** via audio-conditioned generation
- **Non-verbal expressions** support: `(laughs)`, `(sighs)`, `(gasps)`, etc.
- **Batch processing** for multiple text inputs

## Technical Improvements
- Enhanced Snake1d implementation
- Improved inference using `torch.inference_mode`
- Default codec factory pattern for easier model loading
- Updated example project with Dia TTS support

##  License Change: MIT → Apache 2.0
Starting with v0.4.0, transitioning to Apache 2.0 for:
- Better patent protection
- Industry alignment with modern audio/ML libraries
- Clearer contribution guidelines
- Continued open-source with additional protections